### PR TITLE
Fix add_overlap callback firing only once

### DIFF
--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -206,7 +206,7 @@ PhaserGame <- R6::R6Class(
       shiny::observeEvent(input[[input_id]], {
         evt <- input[[input_id]]
         callback_fun(evt)
-      }, ignoreNULL = TRUE, once = TRUE)
+      }, ignoreNULL = TRUE)
     },
 
    are_overlap = function(object_one_name,


### PR DESCRIPTION
### Motivation
- The `add_overlap()` observer was registered with `once = TRUE`, which caused the overlap callback to be removed after the first event and prevented subsequent apple pickups from triggering the handler.

### Description
- Removed `once = TRUE` from the `shiny::observeEvent(...)` call inside `add_overlap()` in `R/PhaserGame.R` so overlap callbacks will fire on every overlap event.

### Testing
- Attempted to parse `R/PhaserGame.R` with `Rscript -e "parse(file='R/PhaserGame.R')"`, but the command failed because `Rscript` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f3524524832fbece5d496ec61b13)