### PR TITLE
Auto-detect spritesheet frameCount and JSON-encode sprite identifiers

### DIFF
--- a/R/sprites.R
+++ b/R/sprites.R
@@ -7,16 +7,20 @@ Sprite <- R6::R6Class(
     #' @param y Numeric. Y-coordinate in pixels.
     #' @param frameWidth Numeric. Width of each frame.
     #' @param frameHeight Numeric. Height of each frame.
-    #' @param frameCount Numeric. Number of frames in the spritesheet.
+    #' @param frameCount Numeric. Number of frames in the spritesheet. If NULL, auto-detect from spritesheet dimensions.
     #' @param frameRate Numeric. Frames per second for the idle animation.
     initialize = function(name, url, x, y,
-                          frameWidth, frameHeight, frameCount, frameRate,
+                          frameWidth, frameHeight, frameCount = NULL, frameRate,
                           session = getDefaultReactiveDomain()) {
       private$session <- session
       private$name <- name
       js <- sprintf(
-        "addSprite('%s', '%s', %d, %d, %d, %d, %d, %d);",
-        name, url, x, y, frameWidth, frameHeight, frameCount, frameRate
+        "addSprite(%s, %s, %d, %d, %d, %d, %s, %d);",
+        jsonlite::toJSON(name, auto_unbox = TRUE),
+        jsonlite::toJSON(url, auto_unbox = TRUE),
+        x, y, frameWidth, frameHeight,
+        if (is.null(frameCount)) "null" else as.character(as.integer(frameCount)),
+        frameRate
       )
       send_js(private, js)
     },
@@ -25,15 +29,20 @@ Sprite <- R6::R6Class(
     #' @param url Character. URL or path to the spritesheet.
     #' @param frameWidth Numeric. Width of each frame.
     #' @param frameHeight Numeric. Height of each frame.
-    #' @param frameCount Numeric. Number of frames in the spritesheet.
+    #' @param frameCount Numeric. Number of frames in the spritesheet. If NULL, auto-detect from spritesheet dimensions.
     #' @param frameRate Numeric. Frames per second for playback.
     #' @return Invisible; sends a custom message to the client.
     add_animation = function(suffix, url,
                              frameWidth, frameHeight,
-                             frameCount, frameRate) {
+                             frameCount = NULL, frameRate) {
       js <- sprintf(
-        "addSpriteAnimation('%s','%s','%s',%d,%d,%d,%d);",
-        private$name, suffix, url, frameWidth, frameHeight, frameCount, frameRate
+        "addSpriteAnimation(%s,%s,%s,%d,%d,%s,%d);",
+        jsonlite::toJSON(private$name, auto_unbox = TRUE),
+        jsonlite::toJSON(suffix, auto_unbox = TRUE),
+        jsonlite::toJSON(url, auto_unbox = TRUE),
+        frameWidth, frameHeight,
+        if (is.null(frameCount)) "null" else as.character(as.integer(frameCount)),
+        frameRate
       )
       send_js(private, js)
     },

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -1,6 +1,24 @@
 window.GameBridge = window.GameBridge || {};
 GameBridge.keyControlHandlers = GameBridge.keyControlHandlers || {};
 
+
+function resolveFrameCount(textureKey, frameWidth, frameHeight, frameCount) {
+  if (Number.isFinite(frameCount) && frameCount > 0) {
+    return Math.floor(frameCount);
+  }
+
+  const texture = scene.textures.get(textureKey);
+  const sourceImage = texture && texture.source && texture.source[0] && texture.source[0].image;
+  if (!sourceImage || frameWidth <= 0 || frameHeight <= 0) {
+    return 1;
+  }
+
+  const cols = Math.floor(sourceImage.width / frameWidth);
+  const rows = Math.floor(sourceImage.height / frameHeight);
+  const detected = cols * rows;
+  return detected > 0 ? detected : 1;
+}
+
 function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRate) {
   scene.load.spritesheet(name, url, {
     frameWidth: frameWidth,
@@ -8,11 +26,13 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
   });
 
   scene.load.once('complete', () => {
+    const resolvedFrameCount = resolveFrameCount(name, frameWidth, frameHeight, frameCount);
+
     scene.anims.create({
       key: name + '_idle',
       frames: scene.anims.generateFrameNumbers(name, {
         start: 0,
-        end: frameCount - 1
+        end: resolvedFrameCount - 1
       }),
       frameRate: frameRate,
       repeat: -1
@@ -51,11 +71,13 @@ function addSpriteAnimation(name, suffix, url, frameWidth, frameHeight, frameCou
     frameHeight: frameHeight
   });
   scene.load.once("complete", () => {
+    const resolvedFrameCount = resolveFrameCount(animKey, frameWidth, frameHeight, frameCount);
+
     scene.anims.create({
       key: animKey,
       frames: scene.anims.generateFrameNumbers(animKey, {
         start: 0,
-        end: frameCount - 1
+        end: resolvedFrameCount - 1
       }),
       frameRate: frameRate,
       repeat: -1


### PR DESCRIPTION
### Motivation
- Allow callers to omit `frameCount` so the spritesheet frame count can be auto-detected from the image dimensions. 
- Safely serialize R strings when sending commands to the client so names and URLs are quoted/escaped correctly.

### Description
- Updated the R `Sprite` methods to make `frameCount` optional (`frameCount = NULL`) and to JSON-encode `name` and `url` with `jsonlite::toJSON`, sending literal `null` to the client when omitted. 
- Changed the JS API payload format to accept `null` for frame count and added a new `resolveFrameCount` helper in `inst/www/phaser-sprite.js` that computes the number of frames from the spritesheet image size and the provided `frameWidth`/`frameHeight`, with a safe fallback to `1`. 
- Rewired animation creation in `addSprite` and `addSpriteAnimation` to use the resolved frame count (`resolvedFrameCount - 1`) when generating frame numbers. 
- Kept existing animation playback and control functions unchanged aside from the above integrations.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62bc7bb98832fa919a20c6f50a093)