### PR TITLE
Fix undefined sprite.play crash when advancing to level 2 in hedgehog example

### DIFF
--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -86,13 +86,25 @@ function addSpriteAnimation(name, suffix, url, frameWidth, frameHeight, frameCou
   scene.load.start();
 }
 
+
+function getSpriteByName(name, caller) {
+  const sprite = scene && scene[name];
+  if (!sprite) {
+    console.warn(`${caller}: sprite "${name}" not found`);
+    return null;
+  }
+  return sprite;
+}
+
 function playAnimation(name, animName) {
-  const sprite = scene[name];
+  const sprite = getSpriteByName(name, "playAnimation()");
+  if (!sprite) return;
   sprite.play(animName, true);
 }
 
 function playAnimationForDuration(name, animName, duration) {
-  const sprite = scene[name];
+  const sprite = getSpriteByName(name, "playAnimationForDuration()");
+  if (!sprite) return;
   sprite.play(animName, true);
   scene.time.delayedCall(duration, () => {
     if (scene.anims.exists(name + "_idle")) {
@@ -124,7 +136,8 @@ function setBounce(name, x) {
 }
 
 function destroySprite(name) {
-  const sprite = scene[name];
+  const sprite = getSpriteByName(name, "destroySprite()");
+  if (!sprite) return;
   sprite.destroy();
 }
 
@@ -176,6 +189,7 @@ function setSpriteInMotion(name, dirX, dirY, speed, distance) {
       duration: duration,
       ease: 'Linear',
       onStart: () => {
+        if (!sprite || !sprite.active || !sprite.play) return;
         if (dirX < 0 && scene.anims.exists(name + "_move_left")) {
           sprite.play(name + "_move_left", true);
         } else if (dirX > 0 && scene.anims.exists(name + "_move_right")) {
@@ -187,6 +201,7 @@ function setSpriteInMotion(name, dirX, dirY, speed, distance) {
         }
       },
       onComplete: () => {
+        if (!sprite || !sprite.active) return;
         playTypeAnim(sprite, name, "idle");
       }
     });


### PR DESCRIPTION
### Motivation
- Prevent console crash `Cannot read properties of undefined (reading 'play')` that occurs when level 1 teardown and level 2 setup overlap and tween/animation callbacks run against destroyed sprites.
- Make sprite animation and destroy entry points robust to missing or inactive sprites during asynchronous transitions.

### Description
- Added a `getSpriteByName(name, caller)` helper in `inst/www/phaser-sprite.js` to safely resolve sprites and log a warning when missing.
- Updated `playAnimation()`, `playAnimationForDuration()`, and `destroySprite()` to no-op (with a warning) when the target sprite is not found.
- Hardened `setSpriteInMotion()` tween hooks by adding guards in `onStart` and `onComplete` to skip animation calls if `sprite` is missing or inactive.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ba00d638832fb49a100f5577ed74)