### PR TITLE
Fix duplicate apple scoring in hedgehog example

### DIFF
--- a/inst/examples/hedgehog.R
+++ b/inst/examples/hedgehog.R
@@ -16,6 +16,7 @@ server <- function(input, output, session) {
   state$game_over <- FALSE
   state$started <- FALSE
   state$levels <- list()
+  state$collected <- list()
 
   level_config <- list(
     `1` = list(
@@ -141,6 +142,11 @@ server <- function(input, output, session) {
 
     game$add_overlap("hedgehog", group_name = paste0("apples_lvl", level_id), callback_fun = function(evt) {
       if (!state$started || state$current_level != level_id || state$game_over) return(invisible(NULL))
+
+      apple_key <- paste(evt$x2, evt$y2, sep = ":")
+      if (isTRUE(state$collected[[apple_key]])) return(invisible(NULL))
+      state$collected[[apple_key]] <- TRUE
+
       state$score <- state$score + 1
       score_text$set(paste0("Level ", level_id, " score: ", state$score))
       apples_group$disable(evt)
@@ -159,6 +165,7 @@ server <- function(input, output, session) {
                 state$levels[[as.character(next_level)]] <- init_level(next_level)
               }
               state$score <- 0
+              state$collected <- list()
               state$current_level <- next_level
               score_text$set(paste0("Level ", state$current_level, " score: 0"))
             }


### PR DESCRIPTION
### Motivation
- Overlap callbacks for apples could fire multiple times before the sprite was disabled, causing a single apple to add 2–3 points instead of one.

### Description
- Add a per-level `state$collected` tracker (a list) to `inst/examples/hedgehog.R` to record processed apple coordinates.
- In the apple overlap callback, compute an `apple_key` from `evt$x2` and `evt$y2` and return early if that key is already `TRUE`, then mark it `TRUE` before updating the score and disabling the apple.
- Reset `state$collected` to an empty list when advancing to the next level so scoring is fresh per level.

### Testing
- Attempted to parse the modified example with `R -q -e "parse('inst/examples/hedgehog.R')"`, but the command failed because `R` is not available in this environment so runtime validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ebd4a920832f8f67d81625524866)