### PR TITLE
Add temporary spacebar speed boost to hedgehog example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phaserR
 Title: An R Interface to the Phaser.js Game Framework
-Version: 0.0.0.9024
+Version: 0.0.0.9025
 Authors@R: 
     person(
       given = "Maciej", 

--- a/inst/examples/hedgehog.R
+++ b/inst/examples/hedgehog.R
@@ -17,6 +17,11 @@ server <- function(input, output, session) {
   state$started <- FALSE
   state$levels <- list()
   state$collected <- list()
+  state$is_boosting <- FALSE
+
+  base_speed <- 250
+  boost_speed <- 650
+  boost_duration <- 1
 
   level_config <- list(
     `1` = list(
@@ -130,7 +135,7 @@ server <- function(input, output, session) {
       type = "info", closeOnClickOutside = FALSE, showCancelButton = FALSE,
       callbackR = function(value) {
         state$started <- TRUE
-        hedgehog$add_player_controls(directions = c("left", "right", "up", "down"), speed = 250)
+        hedgehog$add_player_controls(directions = c("left", "right", "up", "down"), speed = base_speed)
       }
     )
     cfg <- level_config[[as.character(level_id)]]
@@ -182,6 +187,21 @@ server <- function(input, output, session) {
 
     list(apples = apples_group, attackers = attackers)
   }
+
+
+  game$add_control("Space", action = function() {
+    if (!state$started || state$game_over || state$is_boosting) return(invisible(NULL))
+
+    state$is_boosting <- TRUE
+    hedgehog$add_player_controls(directions = c("left", "right", "up", "down"), speed = boost_speed)
+
+    later::later(function() {
+      state$is_boosting <- FALSE
+      if (state$started && !state$game_over) {
+        hedgehog$add_player_controls(directions = c("left", "right", "up", "down"), speed = base_speed)
+      }
+    }, delay = boost_duration)
+  }, input = input)
 
   state$levels[["1"]] <- init_level(1)
 


### PR DESCRIPTION
### Motivation
- Add an easy-to-use keyboard action so players can press `Space` to give the hedgehog a temporary speed boost during gameplay.

### Description
- Introduce `state$is_boosting` plus movement constants `base_speed`, `boost_speed`, and `boost_duration` to the hedgehog example for configurable boost behavior.
- Use the baseline `base_speed` for normal controls by changing the initial `hedgehog$add_player_controls(...)` call to use `base_speed`.
- Register a `Space` key handler with `game$add_control("Space", ...)` that sets boosted controls (`boost_speed`) and uses `later::later()` to restore baseline controls after `boost_duration` seconds while preventing stacked boosts.

### Testing
- Attempted a static parse check with `Rscript -e "parse(file='inst/examples/hedgehog.R')"`, which failed because `Rscript` is not available in this environment.
- Verified repository state and committed the changes with `git commit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdea21284832fad09a44103002a36)