### PR TITLE
Play direction-specific forced animations during boost

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phaserR
 Title: An R Interface to the Phaser.js Game Framework
-Version: 0.0.0.9026
+Version: 0.0.0.9027
 Authors@R: 
     person(
       given = "Maciej", 

--- a/inst/examples/hedgehog.R
+++ b/inst/examples/hedgehog.R
@@ -67,7 +67,7 @@ server <- function(input, output, session) {
   })
   purrr::walk(moves, function(move) {
     hedgehog$add_animation(
-      suffix = "run", 
+      suffix = paste0("run_", move), 
       url = paste0("assets/hedgehog/sprites/hedgehog_run_", move, "_32.png"),
       frameWidth = 32,
       frameHeight = 32,

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -78,7 +78,16 @@ function initPhaserGame(containerId, config) {
           const forced = GameBridge.forcedAnimations[name];
           if (forced) {
             if (forced.until === null || time <= forced.until) {
-              playIfChanged(sprite, forced.key);
+              const directionSuffix = targetAnim.startsWith(name + '_')
+                ? targetAnim.slice((name + '_').length)
+                : 'idle';
+
+              const directionalForcedKey = forced.key + '_' + directionSuffix;
+              const forcedAnimKey = scene.anims.exists(directionalForcedKey)
+                ? directionalForcedKey
+                : forced.key;
+
+              playIfChanged(sprite, forcedAnimKey);
               return;
             }
             delete GameBridge.forcedAnimations[name];


### PR DESCRIPTION
### Motivation
- Pressing Space triggered a single forced run animation key regardless of movement direction, so directional run sprites (e.g. `hedgehog_run_move_left`) were never used.

### Description
- Updated forced-animation handling in `inst/www/phaser-game.js` so that when a forced animation is active the code computes the current movement suffix from `targetAnim` and attempts to play a directional forced key like `forced.key + '_' + directionSuffix`, falling back to the original `forced.key` when the directional variant does not exist.

### Testing
- No automated tests were run for this change (there is no automated runtime test coverage for the Phaser example in this repo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0172939e40832f912f616f3f4e5eda)