### PR TITLE
Add tests for core R6 methods and sample/hedgehog assets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phaserR
 Title: An R Interface to the Phaser.js Game Framework
-Version: 0.0.0.9029
+Version: 0.0.0.9030
 Authors@R: 
     person(
       given = "Maciej", 

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -1,0 +1,78 @@
+make_mock_session <- function() {
+  msgs <- list()
+  env <- new.env(parent = emptyenv())
+  env$sendCustomMessage <- function(type, message) {
+    msgs[[length(msgs) + 1]] <<- list(type = type, message = message)
+  }
+  env$get_messages <- function() msgs
+  env
+}
+
+test_that("Image and Rectangle methods send expected JS", {
+  session <- make_mock_session()
+  img <- Image$new("ground", "ground.png", 10, 20, TRUE, FALSE, session = session)
+  img$show()
+  img$hide()
+
+  rect <- Rectangle$new("hitbox", 1, 2, 3, 4, "0xff00ff", TRUE, TRUE, session = session)
+  rect$show()
+  rect$hide()
+
+  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
+  expect_true(any(grepl("addImage\\('ground', 'ground.png', 10, 20, true, false\\);", msgs)))
+  expect_true(any(grepl("showImage\\('ground'\\);", msgs)))
+  expect_true(any(grepl("hideImage\\('ground'\\);", msgs)))
+  expect_true(any(grepl("addRectangle\\('hitbox', 1, 2, 3, 4, 0xff00ff, true, true\\);", msgs)))
+  expect_true(any(grepl("showImage\\('hitbox'\\);", msgs)))
+  expect_true(any(grepl("hideImage\\('hitbox'\\);", msgs)))
+})
+
+test_that("Group and StaticGroup methods send expected JS", {
+  session <- make_mock_session()
+  g <- Group$new("enemies", session = session)
+  g$add_animation("walk", "enemy.png", 16, 16, 4, 10)
+  g$create(50, 60)
+
+  sg <- StaticGroup$new("obstacles", "box.png", session = session)
+  sg$create(5, 6)
+  sg$disable(list(x2 = 5, y2 = 6))
+
+  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
+  expect_true(any(grepl("addGroup\\('enemies'\\);", msgs)))
+  expect_true(any(grepl("addGroupAnimation\\('enemies','walk','enemy.png',16,16,4,10\\);", msgs)))
+  expect_true(any(grepl("addToGroup\\('enemies', 50, 60\\);", msgs)))
+  expect_true(any(grepl("addStaticGroup\\('obstacles','box.png'\\);", msgs)))
+  expect_true(any(grepl("disableBody\\('obstacles', 5, 6\\);", msgs)))
+})
+
+test_that("Sprite utility methods send expected JS", {
+  session <- make_mock_session()
+  s <- Sprite$new("hero", "hero.png", 0, 0, 32, 32, frameCount = 4, frameRate = 12, session = session)
+  s$play_animation("idle")
+  s$play_animation("run", duration = 300)
+  s$add_player_controls(c("left", "right"), speed = 180)
+  s$set_velocity_x(120)
+  s$set_velocity_y(140)
+  s$set_gravity(1, 2)
+  s$set_bounce(0.5)
+  s$set_in_motion(1, 0, 90, 45, lag = 0)
+  s$destroy()
+
+  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
+  expect_true(any(grepl("playAnimation\\('hero','idle'\\);", msgs)))
+  expect_true(any(grepl("playAnimationForDuration\\('hero','run', 300\\);", msgs)))
+  expect_true(any(grepl("addPlayerControls\\('hero',", msgs)))
+  expect_true(any(grepl("setVelocityX\\('hero', 120\\);", msgs)))
+  expect_true(any(grepl("setVelocityY\\('hero', 140\\);", msgs)))
+  expect_true(any(grepl("setGravity\\('hero', 1, 2\\);", msgs)))
+  expect_true(any(grepl("setBounce\\('hero', 0.500000\\);", msgs)))
+  expect_true(any(grepl("setSpriteInMotion\\('hero', 1, 0, 90, 45\\);", msgs)))
+  expect_true(any(grepl("destroySprite\\('hero'\\);", msgs)))
+})
+
+test_that("sample app and hedgehog assets are available", {
+  sample_app <- system.file("sample_app", "app.R", package = "phaserR")
+  expect_true(file.exists(sample_app))
+  expect_true(file.exists(system.file("assets", "hedgehog", "terrain", "grass.png", package = "phaserR")))
+  expect_true(file.exists(system.file("assets", "rpg_game", "obstacles", "rock.png", package = "phaserR")))
+})


### PR DESCRIPTION
### Motivation
- Increase unit test coverage for core R6 classes so method-level behavior is validated without a browser harness. 
- Ensure sample app and primary hedgehog assets are present for examples and collision-test scenarios. 
- Provide deterministic checks of emitted JS messages to make future refactors safer.

### Description
- Added a new test suite `tests/testthat/test-core-methods.R` that captures `sendCustomMessage` payloads via a reusable `make_mock_session` helper. 
- Added assertions that validate emitted JS from `Image` and `Rectangle` constructors and methods (`initialize`, `show`, `hide`).
- Added assertions for `Group` and `StaticGroup` flows (`initialize`, `add_animation`, `create`, `disable`) and for `Sprite` utility methods (`play_animation`, timed animation, controls, velocity, gravity, bounce, motion, `destroy`).
- Added an availability test that verifies `inst/sample_app/app.R` exists and that bundled hedgehog asset (`assets/hedgehog/terrain/grass.png`) and a collision-friendly obstacle asset (`assets/rpg_game/obstacles/rock.png`) are present.

### Testing
- Attempted to run `testthat::test_dir("tests/testthat")` but it failed in this environment because `R` is not installed (`R: command not found`).
- The new test file was added and committed as `tests/testthat/test-core-methods.R` (no automated test run succeeded due to the missing `R` runtime).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a040f6ca278832f897dd40899b0a210)