### PR TITLE
Standardize API parameter names to snake_case and update docs/examples/tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phaserR
 Title: An R Interface to the Phaser.js Game Framework
-Version: 0.0.0.9031
+Version: 0.0.0.9032
 Authors@R: 
     person(
       given = "Maciej", 

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -58,7 +58,7 @@ PhaserGame <- R6::R6Class(
       )
     },
 
-    add_text = function(text, id, x, y, style = list(fontSize = '22px')) {
+    add_text = function(text, id, x, y, style = list(font_size = '22px')) {
       return(TextObject$new(text, id, x, y, style))
     },
 
@@ -77,24 +77,24 @@ PhaserGame <- R6::R6Class(
     },
 
     #' @description Add a background (tilemap) layer from Tiled JSON + tileset image(s).
-    #' @param mapKey Character. Key for the tilemap JSON.
-    #' @param mapUrl Character. URL of the Tiled JSON file (relative to www/assets/).
-    #' @param tilesetUrls Character vector. URLs of tileset image files.
-    #' @param tilesetNames Character vector. Names of tilesets as defined in Tiled.
-    #' @param layerName Character. Name of the layer to render from Tiled.
+    #' @param map_key Character. Key for the tilemap JSON.
+    #' @param map_url Character. URL of the Tiled JSON file (relative to www/assets/).
+    #' @param tileset_urls Character vector. URLs of tileset image files.
+    #' @param tileset_names Character vector. Names of tilesets as defined in Tiled.
+    #' @param layer_name Character. Name of the layer to render from Tiled.
     #' @return Invisible; sends a custom message to the client.
-    add_map = function(mapKey,
-                       mapUrl,
-                       tilesetUrls,
-                       tilesetNames,
-                       layerName) {
+    add_map = function(map_key,
+                       map_url,
+                       tileset_urls,
+                       tileset_names,
+                       layer_name) {
       js <- sprintf(
         "addMap(%s, %s, %s, %s, %s);",
-        jsonlite::toJSON(mapKey, auto_unbox = TRUE),
-        jsonlite::toJSON(mapUrl, auto_unbox = TRUE),
-        jsonlite::toJSON(tilesetUrls, auto_unbox = TRUE),
-        jsonlite::toJSON(tilesetNames, auto_unbox = TRUE),
-        jsonlite::toJSON(layerName, auto_unbox = TRUE)
+        jsonlite::toJSON(map_key, auto_unbox = TRUE),
+        jsonlite::toJSON(map_url, auto_unbox = TRUE),
+        jsonlite::toJSON(tileset_urls, auto_unbox = TRUE),
+        jsonlite::toJSON(tileset_names, auto_unbox = TRUE),
+        jsonlite::toJSON(layer_name, auto_unbox = TRUE)
       )
       send_js(private, js)
     },
@@ -111,15 +111,15 @@ PhaserGame <- R6::R6Class(
     #' @param url Character. URL or path to the spritesheet image.
     #' @param x Numeric. X-coordinate in pixels.
     #' @param y Numeric. Y-coordinate in pixels.
-    #' @param frameWidth Numeric. Width of each frame.
-    #' @param frameHeight Numeric. Height of each frame.
-    #' @param frameCount Numeric. Number of frames in the spritesheet.
-    #' @param frameRate Numeric. Frames per second for the idle animation.
+    #' @param frame_width Numeric. Width of each frame.
+    #' @param frame_height Numeric. Height of each frame.
+    #' @param frame_count Numeric. Number of frames in the spritesheet.
+    #' @param frame_rate Numeric. Frames per second for the idle animation.
     add_sprite = function(name, url,
                           x, y,
-                          frameWidth, frameHeight,
-                          frameCount = 1, frameRate = 1) {
-      return(Sprite$new(name, url, x, y, frameWidth, frameHeight, frameCount, frameRate))
+                          frame_width, frame_height,
+                          frame_count = 1, frame_rate = 1) {
+      return(Sprite$new(name, url, x, y, frame_width, frame_height, frame_count, frame_rate))
     },
 
     #' @description Adds a dynamic group from a spritesheet.
@@ -148,25 +148,25 @@ PhaserGame <- R6::R6Class(
     },
 
     #' @description Adds a collider between two game objects.
-    #' @param object_one_name Character. Name of the first object.
-    #' @param object_two_name Character. Name of the second object.
-    add_collider = function(object_one_name,
-                            object_two_name = NULL,
+    #' @param object_name Character. Name of the first object.
+    #' @param object_two Character. Name of the second object.
+    add_collider = function(object_name,
+                            object_two = NULL,
                             group_name      = NULL,
                             callback_fun    = NULL,
                             input) {
       input_id <- paste(
-        c("collide", object_one_name,
-          object_two_name %||% group_name),
+        c("collide", object_name,
+          object_two %||% group_name),
         collapse = "_"
       )
 
-      js <- if (!is.null(object_two_name)) {
+      js <- if (!is.null(object_two)) {
         sprintf("addCollider('%s','%s','%s')",
-                object_one_name, object_two_name, input_id)
+                object_name, object_two, input_id)
       } else {
         sprintf("addGroupCollider('%s','%s','%s')",
-                object_one_name, group_name, input_id)
+                object_name, group_name, input_id)
       }
       send_js(private, js)
       if (!is.null(callback_fun)) {
@@ -178,28 +178,28 @@ PhaserGame <- R6::R6Class(
     },
 
     #' @description Adds a collider between two game objects.
-    #' @param object_one_name Character. Name of the first object.
-    #' @param object_two_name Character. Name of the second object.
+    #' @param object_name Character. Name of the first object.
+    #' @param object_two Character. Name of the second object.
     #' @param group_name Character. Name of the group.
     #' @param callback_fun A function to be run when overlap occurs.
-    add_overlap = function(object_one_name,
-                           object_two_name = NULL,
+    add_overlap = function(object_name,
+                           object_two = NULL,
                            group_name      = NULL,
                            callback_fun,
                            input) {
       Sys.sleep(0.1)
       input_id <- paste(
-        c("overlap", object_one_name,
-          object_two_name %||% group_name),
+        c("overlap", object_name,
+          object_two %||% group_name),
         collapse = "_"
       )
 
-      js <- if (!is.null(object_two_name)) {
+      js <- if (!is.null(object_two)) {
         sprintf("addOverlap('%s','%s','%s')",
-                object_one_name, object_two_name, input_id)
+                object_name, object_two, input_id)
       } else {
         sprintf("addGroupOverlap('%s','%s','%s')",
-                object_one_name, group_name, input_id)
+                object_name, group_name, input_id)
       }
       send_js(private, js)
 

--- a/R/groups.R
+++ b/R/groups.R
@@ -12,12 +12,12 @@ Group <- R6::R6Class(
       Sys.sleep(0.1)
     },
     add_animation = function(suffix, url,
-                             frameWidth, frameHeight,
-                             frameCount, frameRate) {
+                             frame_width, frame_height,
+                             frame_count, frame_rate) {
       js <- sprintf(
         "addGroupAnimation('%s','%s','%s',%d,%d,%d,%d);",
         private$name, suffix, url,
-        frameWidth, frameHeight, frameCount, frameRate
+        frame_width, frame_height, frame_count, frame_rate
       )
       send_js(private, js)
       Sys.sleep(0.1)

--- a/R/sprites.R
+++ b/R/sprites.R
@@ -5,12 +5,12 @@ Sprite <- R6::R6Class(
     #' @param url Character. URL or path to the spritesheet image.
     #' @param x Numeric. X-coordinate in pixels.
     #' @param y Numeric. Y-coordinate in pixels.
-    #' @param frameWidth Numeric. Width of each frame.
-    #' @param frameHeight Numeric. Height of each frame.
-    #' @param frameCount Numeric. Number of frames in the spritesheet. If NULL, auto-detect from spritesheet dimensions.
-    #' @param frameRate Numeric. Frames per second for the idle animation.
+    #' @param frame_width Numeric. Width of each frame.
+    #' @param frame_height Numeric. Height of each frame.
+    #' @param frame_count Numeric. Number of frames in the spritesheet. If NULL, auto-detect from spritesheet dimensions.
+    #' @param frame_rate Numeric. Frames per second for the idle animation.
     initialize = function(name, url, x, y,
-                          frameWidth, frameHeight, frameCount = NULL, frameRate,
+                          frame_width, frame_height, frame_count = NULL, frame_rate,
                           session = getDefaultReactiveDomain()) {
       private$session <- session
       private$name <- name
@@ -18,31 +18,31 @@ Sprite <- R6::R6Class(
         "addSprite(%s, %s, %d, %d, %d, %d, %s, %d);",
         jsonlite::toJSON(name, auto_unbox = TRUE),
         jsonlite::toJSON(url, auto_unbox = TRUE),
-        x, y, frameWidth, frameHeight,
-        if (is.null(frameCount)) "null" else as.character(as.integer(frameCount)),
-        frameRate
+        x, y, frame_width, frame_height,
+        if (is.null(frame_count)) "null" else as.character(as.integer(frame_count)),
+        frame_rate
       )
       send_js(private, js)
     },
     #' @description Load a custom animation for any sprite previously added.
     #' @param suffix Character. Identifier for this animation (e.g. "move_left").
     #' @param url Character. URL or path to the spritesheet.
-    #' @param frameWidth Numeric. Width of each frame.
-    #' @param frameHeight Numeric. Height of each frame.
-    #' @param frameCount Numeric. Number of frames in the spritesheet. If NULL, auto-detect from spritesheet dimensions.
-    #' @param frameRate Numeric. Frames per second for playback.
+    #' @param frame_width Numeric. Width of each frame.
+    #' @param frame_height Numeric. Height of each frame.
+    #' @param frame_count Numeric. Number of frames in the spritesheet. If NULL, auto-detect from spritesheet dimensions.
+    #' @param frame_rate Numeric. Frames per second for playback.
     #' @return Invisible; sends a custom message to the client.
     add_animation = function(suffix, url,
-                             frameWidth, frameHeight,
-                             frameCount = NULL, frameRate) {
+                             frame_width, frame_height,
+                             frame_count = NULL, frame_rate) {
       js <- sprintf(
         "addSpriteAnimation(%s,%s,%s,%d,%d,%s,%d);",
         jsonlite::toJSON(private$name, auto_unbox = TRUE),
         jsonlite::toJSON(suffix, auto_unbox = TRUE),
         jsonlite::toJSON(url, auto_unbox = TRUE),
-        frameWidth, frameHeight,
-        if (is.null(frameCount)) "null" else as.character(as.integer(frameCount)),
-        frameRate
+        frame_width, frame_height,
+        if (is.null(frame_count)) "null" else as.character(as.integer(frame_count)),
+        frame_rate
       )
       send_js(private, js)
     },
@@ -106,20 +106,20 @@ Sprite <- R6::R6Class(
     },
 
     #' @description Move sprite along a vector for a set distance.
-    #' @param dirX Numeric. Horizontal direction (-1 = left, +1 = right, 0 = none).
-    #' @param dirY Numeric. Vertical direction (-1 = up, +1 = down, 0 = none).
+    #' @param dir_x Numeric. Horizontal direction (-1 = left, +1 = right, 0 = none).
+    #' @param dir_y Numeric. Vertical direction (-1 = up, +1 = down, 0 = none).
     #' @param speed Numeric. Speed in pixels/second.
     #' @param distance Numeric. Distance in pixels to travel before stopping.
     #' @param lag Numeric. Optional delay before sending the command (defaults to distance/speed).
-    set_in_motion = function(dirX,
-                             dirY,
+    set_in_motion = function(dir_x,
+                             dir_y,
                              speed,
                              distance,
                              lag = distance/speed) {
       Sys.sleep(lag)
       js <- sprintf(
         "setSpriteInMotion('%s', %d, %d, %d, %d);",
-        private$name, dirX, dirY, speed, distance
+        private$name, dir_x, dir_y, speed, distance
       )
       send_js(private, js)
     }

--- a/inst/examples/hedgehog.R
+++ b/inst/examples/hedgehog.R
@@ -58,24 +58,24 @@ server <- function(input, output, session) {
 
   hedgehog <- game$add_sprite(
     name = "hedgehog", url = "assets/hedgehog/sprites/hedgehog_32.png",
-    x = 120, y = 300, frameWidth = 32, frameHeight = 32, frameCount = 5, frameRate = 6
+    x = 120, y = 300, frame_width = 32, frame_height = 32, frame_count = 5, frame_rate = 6
   )
   purrr::walk(moves, function(move) {
     hedgehog$add_animation(
       suffix = move, 
       url = paste0("assets/hedgehog/sprites/hedgehog_", move, "_32.png"), 
-      frameWidth = 32, 
-      frameHeight = 32, 
-      frameRate = 4
+      frame_width = 32, 
+      frame_height = 32, 
+      frame_rate = 4
     )
   })
   purrr::walk(moves, function(move) {
     hedgehog$add_animation(
       suffix = paste0("run_", move), 
       url = paste0("assets/hedgehog/sprites/hedgehog_run_", move, "_32.png"),
-      frameWidth = 32,
-      frameHeight = 32,
-      frameRate = 8
+      frame_width = 32,
+      frame_height = 32,
+      frame_rate = 8
     )
   })
   
@@ -97,18 +97,18 @@ server <- function(input, output, session) {
         url = paste0("assets/hedgehog/sprites/", enemy_name, "_move_left_50.png"),
         x = spawn_point$x, 
         y = spawn_point$y, 
-        frameWidth = 50, 
-        frameHeight = 50, 
-        frameCount = 1, 
-        frameRate = 1
+        frame_width = 50, 
+        frame_height = 50, 
+        frame_count = 1, 
+        frame_rate = 1
       )
       purrr::walk(moves, function(move) {
         enemy$add_animation(
           suffix = move, 
           url = paste0("assets/hedgehog/sprites/", enemy_name, "_", move, "_50.png"), 
-          frameWidth = 50,
-          frameHeight = 50, 
-          frameRate = 4
+          frame_width = 50,
+          frame_height = 50, 
+          frame_rate = 4
         )
       })
       enemy
@@ -116,7 +116,7 @@ server <- function(input, output, session) {
   }
 
   add_enemy_overlap <- function(name, level_id, enemy_name) {
-    game$add_overlap("hedgehog", object_two_name = name, callback_fun = function(evt) {
+    game$add_overlap("hedgehog", object_two = name, callback_fun = function(evt) {
       if (!state$started || state$game_over || state$current_level != level_id) return(invisible(NULL))
       state$game_over <- TRUE
       shinyalert::shinyalert(
@@ -159,7 +159,7 @@ server <- function(input, output, session) {
     for (i in seq_along(attackers)) add_enemy_overlap(paste0("attacker_lvl", level_id, "_", i), level_id, cfg$enemy_name)
 
     game$add_overlap(
-      object_one_name = "hedgehog", 
+      object_name = "hedgehog", 
       group_name = paste0("apples_lvl", level_id), 
       callback_fun = function(evt) {
         if (!state$started || state$current_level != level_id || state$game_over) return(invisible(NULL))
@@ -218,8 +218,8 @@ server <- function(input, output, session) {
     for (enemy in attackers) {
       dir <- sample(list(c(-1, 0), c(1, 0), c(0, -1), c(0, 1)), 1)[[1]]
       enemy$set_in_motion(
-        dirX = dir[1], 
-        dirY = dir[2], 
+        dir_x = dir[1], 
+        dir_y = dir[2], 
         speed = sample(cfg$speed, 1), 
         distance = sample(cfg$distance, 1), 
         lag = 0

--- a/inst/examples/hedgehog_simple.R
+++ b/inst/examples/hedgehog_simple.R
@@ -22,10 +22,10 @@ server <- function(input, output, session) {
     url = "assets/hedgehog/sprites/hedgehog_32.png",
     x = 140,
     y = 260,
-    frameWidth = 32,
-    frameHeight = 32,
-    frameCount = 5,
-    frameRate = 6
+    frame_width = 32,
+    frame_height = 32,
+    frame_count = 5,
+    frame_rate = 6
   )
 
   hedgehog$add_player_controls(
@@ -41,9 +41,9 @@ server <- function(input, output, session) {
     hedgehog$add_animation(
       suffix = move,
       url = paste0("assets/hedgehog/sprites/hedgehog_", move, "_32.png"),
-      frameWidth = 32,
-      frameHeight = 32,
-      frameRate = 5
+      frame_width = 32,
+      frame_height = 32,
+      frame_rate = 5
     )
   }
 
@@ -65,7 +65,7 @@ server <- function(input, output, session) {
   score_text <- game$add_text(text = "Score: 0", id = "score", x = 20, y = 20)
 
   game$add_overlap(
-    object_one_name = "hedgehog",
+    object_name = "hedgehog",
     group_name = "apples",
     callback_fun = function(evt) {
       apples$disable(evt)
@@ -76,7 +76,7 @@ server <- function(input, output, session) {
   )
 
   game$add_collider(
-    object_one = "hedgehog",
+    object_name = "hedgehog",
     group_name = "rocks"
   )
 
@@ -85,15 +85,15 @@ server <- function(input, output, session) {
     url = "assets/hedgehog/sprites/badger_move_left_50.png",
     x = 700,
     y = 300,
-    frameWidth = 50,
-    frameHeight = 50,
-    frameCount = 1,
-    frameRate = 1
+    frame_width = 50,
+    frame_height = 50,
+    frame_count = 1,
+    frame_rate = 1
   )
 
   game$add_overlap(
-    object_one_name = "hedgehog",
-    object_two_name = "badger",
+    object_name = "hedgehog",
+    object_two = "badger",
     callback_fun = function(evt) {
       shinyalert::shinyalert(
         title = "Game over", type = "error",
@@ -108,8 +108,8 @@ server <- function(input, output, session) {
     shiny::invalidateLater(700, session)
     dir <- sample(list(c(-1, 0), c(1, 0), c(0, -1), c(0, 1)), 1)[[1]]
     enemy$set_in_motion(
-      dirX = dir[1],
-      dirY = dir[2],
+      dir_x = dir[1],
+      dir_y = dir[2],
       speed = 70,
       distance = 150,
       lag = 0

--- a/man/PhaserGame.Rd
+++ b/man/PhaserGame.Rd
@@ -124,7 +124,7 @@ HTML tag list containing dependencies and initialization script.
 \if{latex}{\out{\hypertarget{method-PhaserGame-add_text}{}}}
 \subsection{Method \code{add_text()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_text(text, id, x, y, style = list(fontSize = "22px"))}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_text(text, id, x, y, style = list(font_size = "22px"))}\if{html}{\out{</div>}}
 }
 
 }
@@ -139,10 +139,10 @@ Add a player sprite to the scene as an animated spritesheet.
   url,
   x,
   y,
-  frameWidth,
-  frameHeight,
-  frameCount,
-  frameRate
+  frame_width,
+  frame_height,
+  frame_count,
+  frame_rate
 )}\if{html}{\out{</div>}}
 }
 
@@ -157,13 +157,13 @@ Add a player sprite to the scene as an animated spritesheet.
 
 \item{\code{y}}{Numeric. Y-coordinate in pixels.}
 
-\item{\code{frameWidth}}{Numeric. Width of each frame in the spritesheet.}
+\item{\code{frame_width}}{Numeric. Width of each frame in the spritesheet.}
 
-\item{\code{frameHeight}}{Numeric. Height of each frame in the spritesheet.}
+\item{\code{frame_height}}{Numeric. Height of each frame in the spritesheet.}
 
-\item{\code{frameCount}}{Numeric. Total number of frames.}
+\item{\code{frame_count}}{Numeric. Total number of frames.}
 
-\item{\code{frameRate}}{Numeric. Frames per second for the animation.}
+\item{\code{frame_rate}}{Numeric. Frames per second for the animation.}
 }
 \if{html}{\out{</div>}}
 }
@@ -181,10 +181,10 @@ Load a custom animation for any sprite previously added.
   name,
   suffix,
   url,
-  frameWidth,
-  frameHeight,
-  frameCount,
-  frameRate
+  frame_width,
+  frame_height,
+  frame_count,
+  frame_rate
 )}\if{html}{\out{</div>}}
 }
 
@@ -197,13 +197,13 @@ Load a custom animation for any sprite previously added.
 
 \item{\code{url}}{Character. URL or path to the spritesheet.}
 
-\item{\code{frameWidth}}{Numeric. Width of each frame.}
+\item{\code{frame_width}}{Numeric. Width of each frame.}
 
-\item{\code{frameHeight}}{Numeric. Height of each frame.}
+\item{\code{frame_height}}{Numeric. Height of each frame.}
 
-\item{\code{frameCount}}{Numeric. Number of frames in the spritesheet.}
+\item{\code{frame_count}}{Numeric. Number of frames in the spritesheet.}
 
-\item{\code{frameRate}}{Numeric. Frames per second for playback.}
+\item{\code{frame_rate}}{Numeric. Frames per second for playback.}
 }
 \if{html}{\out{</div>}}
 }
@@ -243,21 +243,21 @@ Invisible; sends a custom message to the client.
 \subsection{Method \code{add_map()}}{
 Add a background (tilemap) layer from Tiled JSON + tileset image(s).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_map(mapKey, mapUrl, tilesetUrls, tilesetNames, layerName)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_map(map_key, map_url, tileset_urls, tileset_names, layer_name)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{mapKey}}{Character. Key for the tilemap JSON.}
+\item{\code{map_key}}{Character. Key for the tilemap JSON.}
 
-\item{\code{mapUrl}}{Character. URL of the Tiled JSON file (relative to www/assets/).}
+\item{\code{map_url}}{Character. URL of the Tiled JSON file (relative to www/assets/).}
 
-\item{\code{tilesetUrls}}{Character vector. URLs of tileset image files.}
+\item{\code{tileset_urls}}{Character vector. URLs of tileset image files.}
 
-\item{\code{tilesetNames}}{Character vector. Names of tilesets as defined in Tiled.}
+\item{\code{tileset_names}}{Character vector. Names of tilesets as defined in Tiled.}
 
-\item{\code{layerName}}{Character. Name of the layer to render from Tiled.}
+\item{\code{layer_name}}{Character. Name of the layer to render from Tiled.}
 }
 \if{html}{\out{</div>}}
 }
@@ -355,15 +355,15 @@ Adds a static group to the scene (non-animated).
 \subsection{Method \code{add_collider()}}{
 Adds a collider between two game objects.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_collider(object_one_name, object_two_name)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_collider(object_name, object_two)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{object_one_name}}{Character. Name of the first object.}
+\item{\code{object_name}}{Character. Name of the first object.}
 
-\item{\code{object_two_name}}{Character. Name of the second object.}
+\item{\code{object_two}}{Character. Name of the second object.}
 }
 \if{html}{\out{</div>}}
 }
@@ -375,8 +375,8 @@ Adds a collider between two game objects.
 Adds a collider between two game objects.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_overlap(
-  object_one_name,
-  object_two_name = NULL,
+  object_name,
+  object_two = NULL,
   group_name = NULL,
   callback_fun,
   input
@@ -386,9 +386,9 @@ Adds a collider between two game objects.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{object_one_name}}{Character. Name of the first object.}
+\item{\code{object_name}}{Character. Name of the first object.}
 
-\item{\code{object_two_name}}{Character. Name of the second object.}
+\item{\code{object_two}}{Character. Name of the second object.}
 
 \item{\code{group_name}}{Character. Name of the group.}
 }
@@ -406,10 +406,10 @@ Load a base spritesheet and create an "idle" animation.
   url,
   x,
   y,
-  frameWidth,
-  frameHeight,
-  frameCount,
-  frameRate
+  frame_width,
+  frame_height,
+  frame_count,
+  frame_rate
 )}\if{html}{\out{</div>}}
 }
 
@@ -424,13 +424,13 @@ Load a base spritesheet and create an "idle" animation.
 
 \item{\code{y}}{Numeric. Y-coordinate in pixels.}
 
-\item{\code{frameWidth}}{Numeric. Width of each frame.}
+\item{\code{frame_width}}{Numeric. Width of each frame.}
 
-\item{\code{frameHeight}}{Numeric. Height of each frame.}
+\item{\code{frame_height}}{Numeric. Height of each frame.}
 
-\item{\code{frameCount}}{Numeric. Number of frames in the spritesheet.}
+\item{\code{frame_count}}{Numeric. Number of frames in the spritesheet.}
 
-\item{\code{frameRate}}{Numeric. Frames per second for the idle animation.}
+\item{\code{frame_rate}}{Numeric. Frames per second for the idle animation.}
 }
 \if{html}{\out{</div>}}
 }
@@ -443,8 +443,8 @@ Move all sprites of a given type along a vector for a set distance.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{PhaserGame$set_sprite_in_motion(
   type,
-  dirX,
-  dirY,
+  dir_x,
+  dir_y,
   speed,
   distance,
   lag = distance/speed
@@ -456,9 +456,9 @@ Move all sprites of a given type along a vector for a set distance.
 \describe{
 \item{\code{type}}{Character. Key used in add_sprite().}
 
-\item{\code{dirX}}{Numeric. Horizontal direction (-1 = left, +1 = right, 0 = none).}
+\item{\code{dir_x}}{Numeric. Horizontal direction (-1 = left, +1 = right, 0 = none).}
 
-\item{\code{dirY}}{Numeric. Vertical direction (-1 = up, +1 = down, 0 = none).}
+\item{\code{dir_y}}{Numeric. Vertical direction (-1 = up, +1 = down, 0 = none).}
 
 \item{\code{speed}}{Numeric. Speed in pixels/second.}
 

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -47,7 +47,7 @@ test_that("Group and StaticGroup methods send expected JS", {
 
 test_that("Sprite utility methods send expected JS", {
   session <- make_mock_session()
-  s <- Sprite$new("hero", "hero.png", 0, 0, 32, 32, frameCount = 4, frameRate = 12, session = session)
+  s <- Sprite$new("hero", "hero.png", 0, 0, 32, 32, frame_count = 4, frame_rate = 12, session = session)
   s$play_animation("idle")
   s$play_animation("run", duration = 300)
   s$add_player_controls(c("left", "right"), speed = 180)

--- a/tests/testthat/test-sprites.R
+++ b/tests/testthat/test-sprites.R
@@ -8,7 +8,7 @@ make_mock_session <- function() {
   env
 }
 
-test_that("Sprite initialize sends null frameCount when omitted", {
+test_that("Sprite initialize sends null frame_count when omitted", {
   session <- make_mock_session()
 
   Sprite$new(
@@ -16,9 +16,9 @@ test_that("Sprite initialize sends null frameCount when omitted", {
     url = "hero.png",
     x = 10,
     y = 20,
-    frameWidth = 16,
-    frameHeight = 16,
-    frameRate = 12,
+    frame_width = 16,
+    frame_height = 16,
+    frame_rate = 12,
     session = session
   )
 
@@ -28,26 +28,26 @@ test_that("Sprite initialize sends null frameCount when omitted", {
   expect_match(msgs[[1]]$message$js, "addSprite\\(\"hero\", \"hero.png\", 10, 20, 16, 16, null, 12\\);")
 })
 
-test_that("Sprite add_animation sends explicit frameCount when provided", {
+test_that("Sprite add_animation sends explicit frame_count when provided", {
   session <- make_mock_session()
   sprite <- Sprite$new(
     name = "hero",
     url = "hero.png",
     x = 0,
     y = 0,
-    frameWidth = 16,
-    frameHeight = 16,
-    frameRate = 8,
+    frame_width = 16,
+    frame_height = 16,
+    frame_rate = 8,
     session = session
   )
 
   sprite$add_animation(
     suffix = "run",
     url = "run.png",
-    frameWidth = 32,
-    frameHeight = 32,
-    frameCount = 6,
-    frameRate = 24
+    frame_width = 32,
+    frame_height = 32,
+    frame_count = 6,
+    frame_rate = 24
   )
 
   msgs <- session$get_messages()

--- a/vignettes/first-game-hedgehog.Rmd
+++ b/vignettes/first-game-hedgehog.Rmd
@@ -22,7 +22,7 @@ This vignette walks through a minimal **shinyphaser** game where a hedgehog:
 - collides with rocks,
 - avoids enemy sprites.
 
-## 1) Basic app structure: `ui` and `server`
+## 1) Basic app structure: `ui` and `server` (why `width`/`height` set the play area and `set_shiny_session()` enables server-side events)
 
 A phaserR game lives inside a regular Shiny app.
 
@@ -47,7 +47,7 @@ server <- function(input, output, session) {
 shinyApp(ui, server)
 ```
 
-## 2) Add first image (background)
+## 2) Add first image (background) (why `name` is a stable object key and `x`/`y` position the terrain center)
 
 First we add simply image which will serve as a background to our game.
 
@@ -90,7 +90,7 @@ shinyApp(ui, server)
 knitr::include_graphics("assets/first_game_2_add_background.png")
 ```
 
-## 3) Add sprite (the player hedgehog)
+## 3) Add sprite (the player hedgehog) (why frame parameters describe spritesheet geometry and animation timing)
 
 Create a player sprite from a sprite sheet.
 ```{r eval=FALSE}
@@ -99,10 +99,10 @@ hedgehog <- game$add_sprite(
   url = "assets/hedgehog/sprites/hedgehog_32.png",
   x = 140,
   y = 260,
-  frameWidth = 32,
-  frameHeight = 32,
-  frameCount = 5,
-  frameRate = 6
+  frame_width = 32,
+  frame_height = 32,
+  frame_count = 5,
+  frame_rate = 6
 )
 ```
 
@@ -136,10 +136,10 @@ server <- function(input, output, session) {
     url = "assets/hedgehog/sprites/hedgehog_32.png",
     x = 140,
     y = 260,
-    frameWidth = 32,
-    frameHeight = 32,
-    frameCount = 5,
-    frameRate = 6
+    frame_width = 32,
+    frame_height = 32,
+    frame_count = 5,
+    frame_rate = 6
   )
 }
 
@@ -150,7 +150,7 @@ shinyApp(ui, server)
 knitr::include_graphics("assets/first_game_3_add_sprite.gif")
 ```
 
-## 4) Add player controls
+## 4) Add player controls (why `directions` limits movement axes and `speed` sets motion responsiveness)
 
 Attach keyboard movement to the sprite.
 
@@ -187,10 +187,10 @@ server <- function(input, output, session) {
     url = "assets/hedgehog/sprites/hedgehog_32.png",
     x = 140,
     y = 260,
-    frameWidth = 32,
-    frameHeight = 32,
-    frameCount = 5,
-    frameRate = 6
+    frame_width = 32,
+    frame_height = 32,
+    frame_count = 5,
+    frame_rate = 6
   )
 
   hedgehog$add_player_controls(
@@ -206,7 +206,7 @@ shinyApp(ui, server)
 knitr::include_graphics("assets/first_game_4_player_controls.gif")
 ```
 
-## 5) Add move animations
+## 5) Add move animations (why we map per-direction animation suffixes to directional spritesheets)
 
 We would like now to apply animation to our hedgehog when he moves.
 
@@ -224,9 +224,9 @@ for (move in moves) {
   hedgehog$add_animation(
     suffix = move,
     url = paste0("assets/hedgehog/sprites/hedgehog_", move, "_32.png"),
-    frameWidth = 32,
-    frameHeight = 32,
-    frameRate = 5
+    frame_width = 32,
+    frame_height = 32,
+    frame_rate = 5
   )
 }
 ```
@@ -258,10 +258,10 @@ server <- function(input, output, session) {
     url = "assets/hedgehog/sprites/hedgehog_32.png",
     x = 140,
     y = 260,
-    frameWidth = 32,
-    frameHeight = 32,
-    frameCount = 5,
-    frameRate = 6
+    frame_width = 32,
+    frame_height = 32,
+    frame_count = 5,
+    frame_rate = 6
   )
 
   hedgehog$add_player_controls(
@@ -275,9 +275,9 @@ server <- function(input, output, session) {
     hedgehog$add_animation(
       suffix = move,
       url = paste0("assets/hedgehog/sprites/hedgehog_", move, "_32.png"),
-      frameWidth = 32,
-      frameHeight = 32,
-      frameRate = 5
+      frame_width = 32,
+      frame_height = 32,
+      frame_rate = 5
     )
   }
 }
@@ -290,7 +290,7 @@ shinyApp(ui, server)
 knitr::include_graphics("assets/first_game_5_move_animation.gif")
 ```
 
-## 6) Add overlap with other objects (collect apples)
+## 6) Add overlap with other objects (collect apples) (why overlap is non-blocking and ideal for pickups + score callbacks)
 
 Use overlap when two objects can share space and trigger events.
 
@@ -305,7 +305,7 @@ apples$create(730, 390)
 score_text <- game$add_text(text = "Score: 0", id = "score", x = 20, y = 20)
 
 game$add_overlap(
-  object_one_name = "hedgehog",
+  object_name = "hedgehog",
   group_name = "apples",
   callback_fun = function(evt) {
     apples$disable(evt)        # hide collected apple
@@ -343,10 +343,10 @@ server <- function(input, output, session) {
     url = "assets/hedgehog/sprites/hedgehog_32.png",
     x = 140,
     y = 260,
-    frameWidth = 32,
-    frameHeight = 32,
-    frameCount = 5,
-    frameRate = 6
+    frame_width = 32,
+    frame_height = 32,
+    frame_count = 5,
+    frame_rate = 6
   )
 
   hedgehog$add_player_controls(
@@ -360,9 +360,9 @@ server <- function(input, output, session) {
     hedgehog$add_animation(
       suffix = move,
       url = paste0("assets/hedgehog/sprites/hedgehog_", move, "_32.png"),
-      frameWidth = 32,
-      frameHeight = 32,
-      frameRate = 5
+      frame_width = 32,
+      frame_height = 32,
+      frame_rate = 5
     )
   }
 
@@ -376,7 +376,7 @@ server <- function(input, output, session) {
   score_text <- game$add_text(text = "Score: 0", id = "score", x = 20, y = 20)
 
   game$add_overlap(
-    object_one_name = "hedgehog",
+    object_name = "hedgehog",
     group_name = "apples",
     callback_fun = function(evt) {
       apples$disable(evt)        # hide collected apple
@@ -394,7 +394,7 @@ shinyApp(ui, server)
 knitr::include_graphics("assets/first_game_6_overlap.gif")
 ```
 
-## 7) Add collision with other objects (rocks)
+## 7) Add collision with other objects (rocks) (why collision creates blocking physics and uses static groups for obstacles)
 
 Use collision when objects should block each other.
 
@@ -418,7 +418,7 @@ rocks$create(
 
 ```{r eval=FALSE}
 game$add_collider(
-  sprite_name = "hedgehog",
+  object_name = "hedgehog",
   group_name = "rocks"
 )
 ```
@@ -450,10 +450,10 @@ server <- function(input, output, session) {
     url = "assets/hedgehog/sprites/hedgehog_32.png",
     x = 140,
     y = 260,
-    frameWidth = 32,
-    frameHeight = 32,
-    frameCount = 5,
-    frameRate = 6
+    frame_width = 32,
+    frame_height = 32,
+    frame_count = 5,
+    frame_rate = 6
   )
 
   hedgehog$add_player_controls(
@@ -469,9 +469,9 @@ server <- function(input, output, session) {
     hedgehog$add_animation(
       suffix = move,
       url = paste0("assets/hedgehog/sprites/hedgehog_", move, "_32.png"),
-      frameWidth = 32,
-      frameHeight = 32,
-      frameRate = 5
+      frame_width = 32,
+      frame_height = 32,
+      frame_rate = 5
     )
   }
 
@@ -493,7 +493,7 @@ server <- function(input, output, session) {
   score_text <- game$add_text(text = "Score: 0", id = "score", x = 20, y = 20)
 
   game$add_overlap(
-    object_one_name = "hedgehog",
+    object_name = "hedgehog",
     group_name = "apples",
     callback_fun = function(evt) {
       apples$disable(evt)        # hide collected apple
@@ -504,7 +504,7 @@ server <- function(input, output, session) {
   )
 
   game$add_collider(
-    object_one = "hedgehog",
+    object_name = "hedgehog",
     group_name = "rocks"
   )
 }
@@ -516,7 +516,7 @@ shinyApp(ui, server)
 knitr::include_graphics("assets/first_game_7_collide.gif")
 ```
 
-## 8) Add enemy sprites
+## 8) Add enemy sprites (why periodic `set_in_motion()` with `dir_x`/`dir_y` creates simple patrol behavior)
 
 Create one or more enemies and move them. If enemy overlaps the player, end game.
 
@@ -526,15 +526,15 @@ enemy <- game$add_sprite(
   url = "assets/hedgehog/sprites/badger_move_left_50.png",
   x = 700,
   y = 300,
-  frameWidth = 50,
-  frameHeight = 50,
-  frameCount = 1,
-  frameRate = 1
+  frame_width = 50,
+  frame_height = 50,
+  frame_count = 1,
+  frame_rate = 1
 )
 
 game$add_overlap(
-  object_one_name = "hedgehog",
-  object_two_name = "badger",
+  object_name = "hedgehog",
+  object_two = "badger",
   callback_fun = function(evt) {
     shinyalert::shinyalert(
       title = "Game over", type = "error",
@@ -549,8 +549,8 @@ shiny::observe({
   shiny::invalidateLater(700, session)
   dir <- sample(list(c(-1, 0), c(1, 0), c(0, -1), c(0, 1)), 1)[[1]]
   enemy$set_in_motion(
-    dirX = dir[1],
-    dirY = dir[2],
+    dir_x = dir[1],
+    dir_y = dir[2],
     speed = 70,
     distance = 150,
     lag = 0
@@ -562,7 +562,7 @@ shiny::observe({
 knitr::include_graphics("assets/first_game_8_full_example.gif")
 ```
 
-## 9) Full minimal app
+## 9) Full minimal app (why combining overlap, collision, and animation produces complete game loop behavior)
 
 Put all pieces together:
 
@@ -591,10 +591,10 @@ server <- function(input, output, session) {
     url = "assets/hedgehog/sprites/hedgehog_32.png",
     x = 140,
     y = 260,
-    frameWidth = 32,
-    frameHeight = 32,
-    frameCount = 5,
-    frameRate = 6
+    frame_width = 32,
+    frame_height = 32,
+    frame_count = 5,
+    frame_rate = 6
   )
 
   hedgehog$add_player_controls(
@@ -610,9 +610,9 @@ server <- function(input, output, session) {
     hedgehog$add_animation(
       suffix = move,
       url = paste0("assets/hedgehog/sprites/hedgehog_", move, "_32.png"),
-      frameWidth = 32,
-      frameHeight = 32,
-      frameRate = 5
+      frame_width = 32,
+      frame_height = 32,
+      frame_rate = 5
     )
   }
 
@@ -634,7 +634,7 @@ server <- function(input, output, session) {
   score_text <- game$add_text(text = "Score: 0", id = "score", x = 20, y = 20)
 
   game$add_overlap(
-    object_one_name = "hedgehog",
+    object_name = "hedgehog",
     group_name = "apples",
     callback_fun = function(evt) {
       apples$disable(evt)
@@ -645,7 +645,7 @@ server <- function(input, output, session) {
   )
 
   game$add_collider(
-    object_one = "hedgehog",
+    object_name = "hedgehog",
     group_name = "rocks"
   )
 
@@ -654,15 +654,15 @@ server <- function(input, output, session) {
     url = "assets/hedgehog/sprites/badger_move_left_50.png",
     x = 700,
     y = 300,
-    frameWidth = 50,
-    frameHeight = 50,
-    frameCount = 1,
-    frameRate = 1
+    frame_width = 50,
+    frame_height = 50,
+    frame_count = 1,
+    frame_rate = 1
   )
 
   game$add_overlap(
-    object_one_name = "hedgehog",
-    object_two_name = "badger",
+    object_name = "hedgehog",
+    object_two = "badger",
     callback_fun = function(evt) {
       shinyalert::shinyalert(
         title = "Game over", type = "error",
@@ -677,8 +677,8 @@ server <- function(input, output, session) {
     shiny::invalidateLater(700, session)
     dir <- sample(list(c(-1, 0), c(1, 0), c(0, -1), c(0, 1)), 1)[[1]]
     enemy$set_in_motion(
-      dirX = dir[1],
-      dirY = dir[2],
+      dir_x = dir[1],
+      dir_y = dir[2],
       speed = 70,
       distance = 150,
       lag = 0


### PR DESCRIPTION
### Motivation
- Standardize function and method parameter names to snake_case for a consistent R-style API and to improve readability across the package.
- Update examples, documentation, and tests to reflect the new parameter names so user-facing code and internal calls remain aligned.

### Description
- Renamed many camelCase parameters to snake_case across the codebase (e.g. `frameWidth` -> `frame_width`, `frameRate` -> `frame_rate`, `mapKey` -> `map_key`, `mapUrl` -> `map_url`, `object_one_name` -> `object_name`, `object_two_name` -> `object_two`, `dirX`/`dirY` -> `dir_x`/`dir_y`, and `fontSize` -> `font_size`) in `R/PhaserGame.R`, `R/sprites.R`, `R/groups.R` and related classes.
- Updated the examples (`inst/examples/hedgehog.R`, `inst/examples/hedgehog_simple.R`), vignettes (`vignettes/first-game-hedgehog.Rmd`), and man pages (`man/PhaserGame.Rd`) to use the new parameter names and explanatory text where appropriate.
- Adjusted unit tests in `tests/testthat/` to match the renamed parameters and assertions regarding emitted JS messages.
- Bumped package `Version` in `DESCRIPTION` from `0.0.0.9031` to `0.0.0.9032`.

### Testing
- Ran the `testthat` suite under `tests/testthat/`, which was updated to use the new parameter names, and all tests passed.
- Verified that example scripts and vignette snippets were updated to use the new parameter names by inspecting the example and vignette files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eda623fd0832fa9c22f45d005af78)