### PR TITLE
Add missing roxygen documentation for Phaser R6 methods

### DIFF
--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -29,6 +29,7 @@ PhaserGame <- R6::R6Class(
       )
     },
 
+    #' @description Set the Shiny session used to send Phaser custom messages.
     #' @param session Shiny session object (default: shiny::getDefaultReactiveDomain()).
     set_shiny_session = function(session = shiny::getDefaultReactiveDomain()) {
       private$session <- session
@@ -58,10 +59,25 @@ PhaserGame <- R6::R6Class(
       )
     },
 
+    #' @description Add a text object to the Phaser scene.
+    #' @param text Character. Text value to display.
+    #' @param id Character. Unique ID for the text object.
+    #' @param x Numeric. X-coordinate in pixels.
+    #' @param y Numeric. Y-coordinate in pixels.
+    #' @param style Named list. Styling options passed to Phaser text rendering.
     add_text = function(text, id, x, y, style = list(font_size = '22px')) {
       return(TextObject$new(text, id, x, y, style))
     },
 
+    #' @description Add a rectangle object to the Phaser scene.
+    #' @param name Character. Unique name for the rectangle.
+    #' @param x Numeric. X-coordinate in pixels.
+    #' @param y Numeric. Y-coordinate in pixels.
+    #' @param width Numeric. Rectangle width in pixels.
+    #' @param height Numeric. Rectangle height in pixels.
+    #' @param color Character. Fill color in Phaser-compatible format.
+    #' @param visible Logical. Whether rectangle is initially visible.
+    #' @param clickable Logical. Whether rectangle emits click events.
     add_rectangle = function(name, x, y, width, height, color, visible = TRUE, clickable = FALSE) {
       return(Rectangle$new(name, x, y, width, height, color, visible, clickable))
     },
@@ -209,6 +225,10 @@ PhaserGame <- R6::R6Class(
       }, ignoreNULL = TRUE)
     },
 
+   #' @description Create a reactive expression for overlap state between two objects.
+   #' @param object_one_name Character. Name of the first object.
+   #' @param object_two_name Character. Name of the second object.
+   #' @param input Shiny input list.
    are_overlap = function(object_one_name,
                           object_two_name,
                           input) {
@@ -225,6 +245,13 @@ PhaserGame <- R6::R6Class(
      })
     },
 
+   #' @description Register a callback fired when overlap between objects ends.
+   #' @param object_one_name Character. Name of the first object.
+   #' @param object_two_name Character. Name of the second object.
+   #' @param group_name Character. Name of the group to compare against.
+   #' @param callback_fun Function. Callback executed when overlap ends.
+   #' @param input Shiny input list.
+   #' @param session Shiny session object.
    add_overlap_end = function(object_one_name,
                               object_two_name = NULL,
                               group_name = NULL,

--- a/R/groups.R
+++ b/R/groups.R
@@ -1,6 +1,9 @@
 Group <- R6::R6Class(
   classname = "Group",
   public = list(
+    #' @description Create a dynamic group in the Phaser scene.
+    #' @param name Character. Unique name of the group.
+    #' @param session Shiny session object.
     initialize = function(name,
                           session = shiny::getDefaultReactiveDomain()) {
       private$name <- name
@@ -11,6 +14,13 @@ Group <- R6::R6Class(
 
       Sys.sleep(0.1)
     },
+    #' @description Add an animation that can be used by members of this group.
+    #' @param suffix Character. Animation suffix/key.
+    #' @param url Character. URL or path to spritesheet.
+    #' @param frame_width Numeric. Width of each frame.
+    #' @param frame_height Numeric. Height of each frame.
+    #' @param frame_count Numeric. Number of frames.
+    #' @param frame_rate Numeric. Frames per second.
     add_animation = function(suffix, url,
                              frame_width, frame_height,
                              frame_count, frame_rate) {
@@ -22,6 +32,9 @@ Group <- R6::R6Class(
       send_js(private, js)
       Sys.sleep(0.1)
     },
+    #' @description Create one group member at a coordinate.
+    #' @param x Numeric. X-coordinate in pixels.
+    #' @param y Numeric. Y-coordinate in pixels.
     create = function(x, y) {
       js <- sprintf(
         "addToGroup('%s', %d, %d);",
@@ -39,6 +52,10 @@ Group <- R6::R6Class(
 StaticGroup <- R6::R6Class(
   classname = "StaticGroup",
   public = list(
+    #' @description Create a static group from a base image.
+    #' @param name Character. Unique name of the group.
+    #' @param url Character. URL or path to image file.
+    #' @param session Shiny session object.
     initialize = function(name, url, session = shiny::getDefaultReactiveDomain()) {
       private$name <- name
       private$session <- session
@@ -48,6 +65,9 @@ StaticGroup <- R6::R6Class(
 
       Sys.sleep(0.1)
     },
+    #' @description Create one static group member at a coordinate.
+    #' @param x Numeric. X-coordinate in pixels.
+    #' @param y Numeric. Y-coordinate in pixels.
     create = function(x, y) {
       js <- sprintf(
         "addToGroup('%s', %d, %d);",
@@ -55,6 +75,8 @@ StaticGroup <- R6::R6Class(
       )
       send_js(private, js)
     },
+    #' @description Disable a static group member body based on overlap event payload.
+    #' @param evt List-like event payload containing x2 and y2 values.
     disable = function(evt) {
       x <- evt$x2
       y <- evt$y2

--- a/R/images.R
+++ b/R/images.R
@@ -1,6 +1,14 @@
 Image <- R6::R6Class(
   classname = "Image",
   public = list(
+    #' @description Add an image object to the Phaser scene.
+    #' @param name Character. Unique name of the image.
+    #' @param url Character. URL or path to image file.
+    #' @param x Numeric. X-coordinate in pixels.
+    #' @param y Numeric. Y-coordinate in pixels.
+    #' @param visible Logical. Whether image is initially visible.
+    #' @param clickable Logical. Whether image emits click events.
+    #' @param session Shiny session object.
     initialize = function(name, url, x, y, visible, clickable,
                           session = getDefaultReactiveDomain()) {
       private$session <- session
@@ -9,10 +17,12 @@ Image <- R6::R6Class(
                     name, url, x, y, tolower(visible), tolower(clickable))
       send_js(private, js)
     },
+    #' @description Show a previously added image.
     show = function() {
       js <- sprintf("showImage('%s');", private$name)
       send_js(private, js)
     },
+    #' @description Hide a previously added image.
     hide = function() {
       js <- sprintf("hideImage('%s');", private$name)
       send_js(private, js)

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -1,6 +1,16 @@
 Rectangle <- R6::R6Class(
   classname = "Rectangle",
   public = list(
+    #' @description Add a rectangle object to the Phaser scene.
+    #' @param name Character. Unique name of the rectangle.
+    #' @param x Numeric. X-coordinate in pixels.
+    #' @param y Numeric. Y-coordinate in pixels.
+    #' @param width Numeric. Rectangle width in pixels.
+    #' @param height Numeric. Rectangle height in pixels.
+    #' @param color Character. Fill color in Phaser-compatible format.
+    #' @param visible Logical. Whether rectangle is initially visible.
+    #' @param clickable Logical. Whether rectangle emits click events.
+    #' @param session Shiny session object.
     initialize = function(name, x, y, width, height, color, visible, clickable,
                           session = getDefaultReactiveDomain()) {
       private$session <- session
@@ -9,10 +19,12 @@ Rectangle <- R6::R6Class(
                     name, x, y, width, height, color, tolower(visible), tolower(clickable))
       send_js(private, js)
     },
+    #' @description Show a previously added rectangle.
     show = function() {
       js <- sprintf("showImage('%s');", private$name)
       send_js(private, js)
     },
+    #' @description Hide a previously added rectangle.
     hide = function() {
       js <- sprintf("hideImage('%s');", private$name)
       send_js(private, js)

--- a/R/sprites.R
+++ b/R/sprites.R
@@ -133,6 +133,12 @@ Sprite <- R6::R6Class(
 StaticSprite <- R6::R6Class(
   classname = "StaticSprite",
   public = list(
+    #' @description Add a non-animated static sprite to the scene.
+    #' @param name Character. Unique name of the sprite.
+    #' @param url Character. URL or path to image file.
+    #' @param x Numeric. X-coordinate in pixels.
+    #' @param y Numeric. Y-coordinate in pixels.
+    #' @param session Shiny session object.
     initialize = function(name, url, x, y, session = getDefaultReactiveDomain()) {
       private$session <- session
       private$name <- name


### PR DESCRIPTION
### Motivation
- Improve developer ergonomics and package documentation by adding missing roxygen descriptions and parameter docs for several R6 classes and methods so generated help pages are complete.
- Make method purposes and expected argument types explicit for users of the `PhaserGame`, `Group`, `StaticGroup`, `Image`, `Rectangle`, and `StaticSprite` classes.

### Description
- Added roxygen `@description` and `@param` docs to `set_shiny_session`, `add_text`, `add_rectangle`, `are_overlap`, and `add_overlap_end` in `R/PhaserGame.R` to clarify behavior and expected inputs.
- Added constructor and method documentation to `Group` and `StaticGroup` in `R/groups.R` for `initialize`, `add_animation`, `create`, and `disable` to document group lifecycle and parameters.
- Added constructor and visibility method documentation to `Image` in `R/images.R` and constructor/visibility docs to `Rectangle` in `R/rectangle.R` to document usage and parameters.
- Added constructor documentation to `StaticSprite` in `R/sprites.R` to document parameters and session handling.

### Testing
- Attempted a syntax/parse check of the modified files with `Rscript -e "files <- c('R/PhaserGame.R','R/sprites.R','R/groups.R','R/images.R','R/rectangle.R'); for (f in files) parse(file=f)"`, but the environment lacks `Rscript` so the check could not be performed.
- No automated R unit tests were executed in this environment after the changes due to missing R tooling.
- Files were reviewed via a code listing to confirm the roxygen blocks are present for the updated methods.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10bbc131f8832f9802c3d52585de74)