### PR TITLE
Remove Sys.sleep calls from methods

### DIFF
--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -208,7 +208,6 @@ PhaserGame <- R6::R6Class(
                            group = NULL,
                            callback_fun,
                            input) {
-      Sys.sleep(0.1)
       input_id <- paste(
         c("overlap", object_one,
           object_two %||% group),

--- a/R/groups.R
+++ b/R/groups.R
@@ -15,8 +15,6 @@ Group <- R6::R6Class(
 
       js <- sprintf("addGroup('%s');",name)
       send_js(private, js)
-
-      Sys.sleep(0.1)
     },
     #' @description Add an animation that can be used by members of this group.
     #' @param suffix Character. Animation suffix/key.
@@ -34,7 +32,6 @@ Group <- R6::R6Class(
         frame_width, frame_height, frame_count, frame_rate
       )
       send_js(private, js)
-      Sys.sleep(0.1)
     },
     #' @description Create one group member at a coordinate.
     #' @param x Numeric. X-coordinate in pixels.
@@ -70,8 +67,6 @@ StaticGroup <- R6::R6Class(
 
       js <- sprintf("addStaticGroup('%s','%s');", name, url)
       send_js(private, js)
-
-      Sys.sleep(0.1)
     },
     #' @description Create one static group member at a coordinate.
     #' @param x Numeric. X-coordinate in pixels.

--- a/R/sprites.R
+++ b/R/sprites.R
@@ -58,7 +58,6 @@ Sprite <- R6::R6Class(
     #' @param duration Numeric. Optional duration in milliseconds to play the animation
     #'  before reverting to idle (defaults to Inf, which loops indefinitely until another animation is played).
     play_animation = function(anim_name, duration = Inf) {
-      Sys.sleep(0.1)
       js <- if (is.infinite(duration)) {
         sprintf(
           "playAnimation('%s','%s');",
@@ -107,7 +106,6 @@ Sprite <- R6::R6Class(
     #' @param y Numeric. Velocity in pixels/second (positive = down, negative =
     #'  up).
     set_gravity = function(x = 100, y = 100) {
-      Sys.sleep(0.1)
       js <- sprintf("setGravity('%s', %d, %d);",
                     private$name, x, y)
       send_js(private, js)
@@ -116,7 +114,6 @@ Sprite <- R6::R6Class(
     #' @description Set the sprite's bounce factor.
     #' @param x Numeric. Bounce factor.
     set_bounce = function(x) {
-      Sys.sleep(0.1)
       js <- sprintf("setBounce('%s', %f);",
                     private$name, x)
       send_js(private, js)
@@ -140,7 +137,6 @@ Sprite <- R6::R6Class(
                              speed,
                              distance,
                              lag = distance/speed) {
-      Sys.sleep(lag)
       js <- sprintf(
         "setSpriteInMotion('%s', %d, %d, %d, %d);",
         private$name, dir_x, dir_y, speed, distance


### PR DESCRIPTION
### Motivation
- Remove artificial `Sys.sleep()` delays from methods to avoid blocking the R process and improve responsiveness.
- Follow the project request to eliminate all `Sys.sleep()` usages inside library methods so behavior is driven by explicit timing in the client or caller code.

### Description
- Deleted `Sys.sleep(0.1)` from `PhaserGame$add_overlap` in `R/PhaserGame.R` so overlap setup immediately generates the input id and dispatches JS.
- Deleted `Sys.sleep(0.1)` from `Group$initialize` and `Group$add_animation`, and from `StaticGroup$initialize` in `R/groups.R` so group creation and animation registration send JS without delays.
- Deleted `Sys.sleep()` calls from `Sprite` methods in `R/sprites.R`, specifically `play_animation`, `set_gravity`, `set_bounce`, and the `lag`-based sleep in `set_in_motion`, preserving the original JS commands and behavior.

### Testing
- Verified no remaining occurrences with `rg -n "Sys\.sleep\s*\(" R tests` which returned no matches.
- Ran `git diff --check` with no whitespace or diff-check issues reported.
- Attempted to run package tests via `Rscript -e 'testthat::test_dir("tests/testthat")'` but this was not executed because `Rscript` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8e0957f0832f91f50418ae36b935)