### PR TITLE
Add visibility controls for text objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyphaser
 Title: An Interface to the 'Phaser.js' Game Framework
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: 
     person(
       given = "Maciej", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# shinyphaser 0.1.0.9000
+
+* Added initial visibility control for text objects via `PhaserGame$add_text(..., visible = FALSE)` and `Text$new(..., visible = FALSE)`.
+* Added `Text$show()` and `Text$hide()` helpers for toggling text objects after creation.
+
 # shinyphaser 0.1.0
 
 Initial CRAN release.

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -65,8 +65,9 @@ PhaserGame <- R6::R6Class(
     #' @param x Numeric. X-coordinate in pixels.
     #' @param y Numeric. Y-coordinate in pixels.
     #' @param style Named list. Styling options passed to Phaser text rendering.
-    add_text = function(text, id, x, y, style = list(font_size = '22px')) {
-      return(Text$new(text, id, x, y, style))
+    #' @param visible Logical. Whether text is initially visible.
+    add_text = function(text, id, x, y, style = list(font_size = '22px'), visible = TRUE) {
+      return(Text$new(text, id, x, y, style, visible))
     },
 
     #' @description Add a rectangle object to the Phaser scene.
@@ -312,10 +313,13 @@ Text <- R6::R6Class(
     #' @param x Numeric. X-coordinate in pixels.
     #' @param y Numeric. Y-coordinate in pixels.
     #' @param style Named list. Styling options passed to Phaser text rendering.
+    #' @param visible Logical. Whether text is initially visible.
     #' @param session Shiny session object.
-    initialize = function(text, id, x, y, style, session = shiny::getDefaultReactiveDomain()) {
-      js <- sprintf("addText('%s', '%s', %d, %d, %s);",
-                    text, id, x, y, jsonlite::toJSON(style, auto_unbox = TRUE))
+    initialize = function(text, id, x, y, style, visible = TRUE,
+                          session = shiny::getDefaultReactiveDomain()) {
+      js <- sprintf("addText('%s', '%s', %d, %d, %s, %s);",
+                    text, id, x, y, jsonlite::toJSON(style, auto_unbox = TRUE),
+                    tolower(visible))
       private$id <- id
       private$session <- session
       send_js(private, js)
@@ -325,6 +329,16 @@ Text <- R6::R6Class(
     set = function(text) {
       js <- sprintf("setText('%s', '%s');",
                     text, private$id)
+      send_js(private, js)
+    },
+    #' @description Show a previously added text object.
+    show = function() {
+      js <- sprintf("showText('%s');", private$id)
+      send_js(private, js)
+    },
+    #' @description Hide a previously added text object.
+    hide = function() {
+      js <- sprintf("hideText('%s');", private$id)
       send_js(private, js)
     }
   ),

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -98,12 +98,21 @@ function initPhaserGame(containerId, config) {
   }
 }
 
-function addText(text, id, x, y, style) {
+function addText(text, id, x, y, style, visible = true) {
   scene[id] = scene.add.text(x, y, text, style);
+  scene[id].setVisible(visible);
 }
 
 function setText(text, id) {
   scene[id].setText(text);
+}
+
+function showText(id) {
+  scene[id].setVisible(true);
+}
+
+function hideText(id) {
+  scene[id].setVisible(false);
 }
 
 function addPlayerControls(name, directions, speed) {

--- a/man/PhaserGame.Rd
+++ b/man/PhaserGame.Rd
@@ -127,7 +127,7 @@ HTML tag list containing dependencies and initialization script.
 \subsection{Method \code{add_text()}}{
 Add a text object to the Phaser scene.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_text(text, id, x, y, style = list(font_size = "22px"))}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_text(text, id, x, y, style = list(font_size = "22px"), visible = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -142,6 +142,8 @@ Add a text object to the Phaser scene.
 \item{\code{y}}{Numeric. Y-coordinate in pixels.}
 
 \item{\code{style}}{Named list. Styling options passed to Phaser text rendering.}
+
+\item{\code{visible}}{Logical. Whether text is initially visible.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Text.Rd
+++ b/man/Text.Rd
@@ -12,6 +12,8 @@ dynamic updates to its content. Created with PhaserGame$add_text() method.
 \itemize{
 \item \href{#method-Text-new}{\code{Text$new()}}
 \item \href{#method-Text-set}{\code{Text$set()}}
+\item \href{#method-Text-show}{\code{Text$show()}}
+\item \href{#method-Text-hide}{\code{Text$hide()}}
 \item \href{#method-Text-clone}{\code{Text$clone()}}
 }
 }
@@ -21,7 +23,15 @@ dynamic updates to its content. Created with PhaserGame$add_text() method.
 \subsection{Method \code{new()}}{
 Create a text object in the Phaser scene.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Text$new(text, id, x, y, style, session = shiny::getDefaultReactiveDomain())}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Text$new(
+  text,
+  id,
+  x,
+  y,
+  style,
+  visible = TRUE,
+  session = shiny::getDefaultReactiveDomain()
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -36,6 +46,8 @@ Create a text object in the Phaser scene.
 \item{\code{y}}{Numeric. Y-coordinate in pixels.}
 
 \item{\code{style}}{Named list. Styling options passed to Phaser text rendering.}
+
+\item{\code{visible}}{Logical. Whether text is initially visible.}
 
 \item{\code{session}}{Shiny session object.}
 }
@@ -59,6 +71,25 @@ Update the text content of this object.
 \if{html}{\out{</div>}}
 }
 }
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Text-show"></a>}}
+\if{latex}{\out{\hypertarget{method-Text-show}{}}}
+\subsection{Method \code{show()}}{
+Show a previously added text object.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Text$show()}\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Text-hide"></a>}}
+\if{latex}{\out{\hypertarget{method-Text-hide}{}}}
+\subsection{Method \code{hide()}}{
+Hide a previously added text object.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Text$hide()}\if{html}{\out{</div>}}
+}
+}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Text-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Text-clone}{}}}

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -70,6 +70,22 @@ test_that("Sprite utility methods send expected JS", {
   expect_true(any(grepl("destroySprite\\('hero'\\);", msgs)))
 })
 
+
+test_that("Text methods send expected JS", {
+  session <- make_mock_session()
+  txt <- Text$new("Score", "score_text", 15, 25, list(font_size = "22px"),
+                  visible = FALSE, session = session)
+  txt$set("Score: 1")
+  txt$show()
+  txt$hide()
+
+  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
+  expect_true(any(grepl("addText\\('Score', 'score_text', 15, 25, .*false\\);", msgs)))
+  expect_true(any(grepl("setText\\('Score: 1', 'score_text'\\);", msgs)))
+  expect_true(any(grepl("showText\\('score_text'\\);", msgs)))
+  expect_true(any(grepl("hideText\\('score_text'\\);", msgs)))
+})
+
 test_that("sample app and hedgehog assets are available", {
   sample_app <- system.file("sample_app", "app.R", package = "shinyphaser")
   expect_true(file.exists(sample_app))


### PR DESCRIPTION
### Motivation
- Provide control over initial visibility and runtime show/hide of text objects so apps can create hidden UI text elements and toggle them without recreating objects.

### Description
- Add a `visible` argument to `PhaserGame$add_text()` and forward it to `Text$new()` so initial visibility can be specified.
- Extend the `Text` R6 class with `visible` handling in the constructor and new `show()` / `hide()` methods that send `showText()` / `hideText()` JS commands.
- Update the browser bridge in `inst/www/phaser-game.js` to accept the `visible` flag in `addText()` and expose `showText()` / `hideText()` helpers that set Phaser visibility.
- Update generated Rd docs (`man/PhaserGame.Rd`, `man/Text.Rd`) and add a unit test in `tests/testthat/test-core-methods.R` covering message dispatch for create/set/show/hide.

### Testing
- Ran JavaScript syntax check with `node --check inst/www/phaser-game.js` which succeeded.
- Ran repository checks with `git diff --check` which produced no issues.
- Documentation generation via `Rscript` was not run in this environment because `Rscript` is not installed, and package tests were therefore not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39481f2974832f89cb9ab14aa18466)