### PR TITLE
Add CRAN downloads badge to README

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyphaser
 Title: An Interface to the 'Phaser.js' Game Framework
-Version: 0.1.0.9000
+Version: 0.1.0.9001
 Authors@R: 
     person(
       given = "Maciej", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
-# shinyphaser 0.1.0.9000
+# shinyphaser (development vesion)
 
 * Added initial visibility control for text objects via `PhaserGame$add_text(..., visible = FALSE)` and `Text$new(..., visible = FALSE)`.
 * Added `Text$show()` and `Text$hide()` helpers for toggling text objects after creation.
+
+* Added CRAN downloads badge to README.
 
 # shinyphaser 0.1.0
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,6 +15,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/maciekbanas/shinyphaser/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/maciekbanas/shinyphaser/actions/workflows/R-CMD-check.yaml)
+[![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/shinyphaser)](https://CRAN.R-project.org/package=shinyphaser)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/shinyphaser)](https://cran.r-project.org/package=shinyphaser)
 <!-- badges: end -->
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,6 +15,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/maciekbanas/shinyphaser/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/maciekbanas/shinyphaser/actions/workflows/R-CMD-check.yaml)
+[![CRAN downloads](https://cranlogs.r-pkg.org/badges/shinyphaser)](https://cran.r-project.org/package=shinyphaser)
 <!-- badges: end -->
 
 This package provides an R Shiny interface to selected features of the [Phaser 3](https://phaser.io/) game framework.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 <!-- badges: start -->
 
 [![R-CMD-check](https://github.com/maciekbanas/shinyphaser/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/maciekbanas/shinyphaser/actions/workflows/R-CMD-check.yaml)
+[![CRAN downloads](https://cranlogs.r-pkg.org/badges/shinyphaser)](https://cran.r-project.org/package=shinyphaser)
 <!-- badges: end -->
 
 This package provides an R Shiny interface to selected features of the


### PR DESCRIPTION
### Motivation
- Add a CRAN downloads badge to the README badges block and keep the generated `README.md` in sync with `README.Rmd`.

### Description
- Inserted the CRAN downloads badge `[![CRAN downloads](https://cranlogs.r-pkg.org/badges/shinyphaser)](https://cran.r-project.org/package=shinyphaser)` into the badges section of `README.Rmd` and updated the generated `README.md` accordingly.

### Testing
- Ran `git diff --check` which passed, and attempted `Rscript -e 'rmarkdown::render("README.Rmd", output_file = "README.md", quiet = TRUE)'` but it could not run because `Rscript` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3953d69a84832f88c7546c7e30461b)