### PR TITLE
Add StaticSprite$destroy() to remove static sprites and update tests/docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyphaser
 Title: An Interface to the 'Phaser.js' Game Framework
-Version: 0.1.0.9001
+Version: 0.1.0.9002
 Authors@R: 
     person(
       given = "Maciej", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# shinyphaser (development vesion)
+# shinyphaser (development version)
+
+* Added `StaticSprite$destroy()` for removing static sprites from the Phaser scene.
 
 * Added initial visibility control for text objects via `PhaserGame$add_text(..., visible = FALSE)` and `Text$new(..., visible = FALSE)`.
 * Added `Text$show()` and `Text$hide()` helpers for toggling text objects after creation.

--- a/R/sprites.R
+++ b/R/sprites.R
@@ -173,6 +173,13 @@ StaticSprite <- R6::R6Class(
       js <- sprintf("addStaticSprite('%s','%s', %s, %s);",
                     name, url, x, y)
       send_js(private, js)
+    },
+
+    #' @description Remove static sprite from the scene.
+    destroy = function() {
+      js <- sprintf("destroySprite('%s');",
+                    private$name)
+      send_js(private, js)
     }
   ),
   private = list(

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 <!-- badges: start -->
 
 [![R-CMD-check](https://github.com/maciekbanas/shinyphaser/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/maciekbanas/shinyphaser/actions/workflows/R-CMD-check.yaml)
-[![CRAN downloads](https://cranlogs.r-pkg.org/badges/shinyphaser)](https://cran.r-project.org/package=shinyphaser)
+[![CRAN
+downloads](https://cranlogs.r-pkg.org/badges/grand-total/shinyphaser)](https://CRAN.R-project.org/package=shinyphaser)
+[![CRAN
+downloads](https://cranlogs.r-pkg.org/badges/shinyphaser)](https://cran.r-project.org/package=shinyphaser)
 <!-- badges: end -->
 
 This package provides an R Shiny interface to selected features of the

--- a/man/StaticSprite.Rd
+++ b/man/StaticSprite.Rd
@@ -11,6 +11,7 @@ with PhaserGame$add_static_sprite() method.
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-StaticSprite-new}{\code{StaticSprite$new()}}
+\item \href{#method-StaticSprite-destroy}{\code{StaticSprite$destroy()}}
 \item \href{#method-StaticSprite-clone}{\code{StaticSprite$clone()}}
 }
 }
@@ -37,6 +38,15 @@ Add a non-animated static sprite to the scene.
 \item{\code{session}}{Shiny session object.}
 }
 \if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-StaticSprite-destroy"></a>}}
+\if{latex}{\out{\hypertarget{method-StaticSprite-destroy}{}}}
+\subsection{Method \code{destroy()}}{
+Remove static sprite from the scene.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{StaticSprite$destroy()}\if{html}{\out{</div>}}
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -45,6 +45,16 @@ test_that("Group and StaticGroup methods send expected JS", {
   expect_true(any(grepl("disableBody\\('obstacles', 5, 6\\);", msgs)))
 })
 
+test_that("StaticSprite destroy sends expected JS", {
+  session <- make_mock_session()
+  static_sprite <- StaticSprite$new("rock", "rock.png", 10, 20, session = session)
+  static_sprite$destroy()
+
+  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
+  expect_true(any(grepl("addStaticSprite\\('rock','rock.png', 10, 20\\);", msgs)))
+  expect_true(any(grepl("destroySprite\\('rock'\\);", msgs)))
+})
+
 test_that("Sprite utility methods send expected JS", {
   session <- make_mock_session()
   s <- Sprite$new("hero", "hero.png", 0, 0, 32, 32, frame_count = 4, frame_rate = 12, session = session)


### PR DESCRIPTION
### Motivation

- Provide a way to remove non-animated static sprites from the Phaser scene from R by emitting a destroy JS call.

### Description

- Added `StaticSprite$destroy()` which sends `destroySprite('<name>');` to the client to remove a static sprite from the scene.
- Updated `man/StaticSprite.Rd` to document the new `destroy()` method.
- Added a unit test in `tests/testthat/test-core-methods.R` to verify that `StaticSprite$new()` and `StaticSprite$destroy()` emit the expected JS messages.
- Bumped package version in `DESCRIPTION` to `0.1.0.9002` and updated `NEWS.md` to mention the new API and fixed a typo.

### Testing

- Ran the package test suite with `devtools::test()` (testthat) and the full test suite passed, including the new `StaticSprite destroy sends expected JS` test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a8edf8e44832f922a173ce74b9e14)