### PR TITLE
Add 'bear' arcade example and update API/renderer for axis-specific controls and naming conventions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinyphaser (development version)
 
+* Added new arcade example game (bear).
+
 * Added camera follow helpers for sprites so the Phaser camera can move with a player sprite.
 
 * Added `StaticSprite$destroy()` for removing static sprites from the Phaser scene.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Added new arcade example game (bear).
 
 * Added camera follow helpers for sprites so the Phaser camera can move with a player sprite.
+* Added `PhaserGame$set_world_bounds()` for configuring Phaser physics world and camera bounds from R.
 
 * Added `StaticSprite$destroy()` for removing static sprites from the Phaser scene.
 

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -117,6 +117,14 @@ PhaserGame <- R6::R6Class(
       send_js(private, js)
     },
 
+    #' @description Set the Phaser physics world and camera bounds.
+    #' @param width Numeric. World width in pixels.
+    #' @param height Numeric. World height in pixels.
+    set_world_bounds = function(width, height) {
+      js <- sprintf("setWorldBounds(%d, %d);", width, height)
+      send_js(private, js)
+    },
+
     #' @description Enable terrain collision for a player sprite.
     #' @param name Character. Name of the player sprite (as added via add_player_sprite).
     enable_terrain_collision = function(name) {

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -120,6 +120,7 @@ PhaserGame <- R6::R6Class(
     #' @description Set the Phaser physics world and camera bounds.
     #' @param width Numeric. World width in pixels.
     #' @param height Numeric. World height in pixels.
+    #' @return Invisible; sends a custom message to the client.
     set_world_bounds = function(width, height) {
       js <- sprintf("setWorldBounds(%d, %d);", width, height)
       send_js(private, js)

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -1,6 +1,6 @@
 devtools::load_all()
 
-game <- PhaserGame$new(width = 1600, height = 800)
+game <- PhaserGame$new(width = 800, height = 800)
 
 ui <- shiny::tagList(
   game$use_phaser()
@@ -10,6 +10,7 @@ server <- function(input, output, session) {
   points <- 0
 
   game$set_shiny_session()
+  game$set_world_bounds(width = 1600, height = 800)
 
   game$add_image(
     name = "sky",
@@ -52,6 +53,7 @@ server <- function(input, output, session) {
     directions = c("left", "right"),
     speed = 300
   )
+  bear$follow_camera(lerp_x = 0.1, lerp_y = 0.1)
 
   game$add_control(
     "Space",

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -2,7 +2,9 @@ devtools::load_all()
 
 game <- PhaserGame$new(width = 1600, height = 800)
 
-ui <- game$ui()
+ui <- shiny::tagList(
+  game$use_phaser()
+)
 
 server <- function(input, output, session) {
   points <- 0
@@ -11,53 +13,50 @@ server <- function(input, output, session) {
 
   game$add_image(
     name = "sky",
-    url = "assets/bear_game/terrain/sky.png",
+    url = "assets/bear/terrain/sky.png",
     x = 800,
-    y = 300
+    y = 400
   )
 
   bear <- game$add_sprite(
     name = "bear",
-    url = "assets/bear_game/player_sprites/bear_idle.png",
+    url = "assets/bear/player_sprites/bear_idle.png",
     x = 100,
     y = 550,
-    frameWidth = 100,
-    frameHeight = 100,
-    frameCount = 10,
-    frameRate = 4
+    frame_width = 100,
+    frame_height = 100,
+    frame_rate = 4
   )
   bear$add_animation(
     suffix = "move_right",
-    url = "assets/bear_game/player_sprites/bear_move_right.png",
-    frameWidth = 100, frameHeight = 100,
-    frameCount = 2, frameRate = 6
+    url = "assets/bear/player_sprites/bear_move_right.png",
+    frame_width = 100,
+    frame_height = 100,
+    frame_rate = 6
   )
   bear$add_animation(
     suffix = "move_left",
-    url = "assets/bear_game/player_sprites/bear_move_left.png",
-    frameWidth = 100, frameHeight = 100,
-    frameCount = 2, frameRate = 6
+    url = "assets/bear/player_sprites/bear_move_left.png",
+    frame_width = 100,
+    frame_height = 100,
+    frame_rate = 6
   )
   bear$add_animation(
     suffix = "jump",
-    url = "assets/bear_game/player_sprites/bear_jump.png",
-    frameWidth = 100, frameHeight = 100,
-    frameCount = 2, frameRate = 6
+    url = "assets/bear/player_sprites/bear_jump.png",
+    frame_width = 100,
+    frame_height = 100,
+    frame_rate = 6
   )
   bear$add_player_controls(
     directions = c("left", "right"),
     speed = 300
   )
-  Sys.sleep(0.1)
+
   game$add_control(
     "Space",
     action = function() {
-      bear$set_in_motion(
-        dirX = 0,
-        dirY = -1,
-        speed = 300,
-        distance = 100
-      )
+      bear$set_velocity_y(-600)
       bear$play_animation(
         anim_name = "bear_jump",
         duration = 250
@@ -67,12 +66,12 @@ server <- function(input, output, session) {
   )
   bear$set_gravity(
     x = 0,
-    y = 8e3
+    y = 1200
   )
 
   apples <- game$add_static_group(
     name = "apples",
-    url = "assets/bear_game/perks/apple.png"
+    url = "assets/bear/perks/apple.png"
   )
   apples$create(
     x = 600,
@@ -86,55 +85,61 @@ server <- function(input, output, session) {
     x = 1200,
     y = 600
   )
+
   grass <- game$add_static_sprite(
     name = "grass",
-    url = "assets/bear_game/terrain/grass.png",
+    url = "assets/bear/terrain/grass.png",
     x = 800,
-    y = 700
+    y = 755
   )
+
   wooden_box <- game$add_sprite(
     name = "wooden_box",
-    url = "assets/bear_game/obstacles/wooden_box.png",
+    url = "assets/bear/obstacles/wooden_box.png",
     x = 300,
     y = 600,
-    frameWidth = 80,
-    frameHeight = 80,
+    frame_width = 80,
+    frame_height = 80
   )
   wooden_box$set_gravity(
     x = 0,
     y = 500
   )
+
   points_text <- game$add_text(
     text = "points: 0",
     id = "points_text",
     x = 100,
     y = 100
   )
-  Sys.sleep(0.1)
+
   game$add_collider(
-    object_one_name = "bear",
-    object_two_name = "grass"
+    object_one = "bear",
+    object_two = "grass",
+    input = input
   )
   game$add_collider(
-    object_one_name = "wooden_box",
-    object_two_name = "grass"
+    object_one = "wooden_box",
+    object_two = "grass",
+    input = input
   )
   game$add_overlap(
-    object_one_name = "bear",
-    object_two_name = "wooden_box",
+    object_one = "bear",
+    object_two = "wooden_box",
     callback_fun = function(evt) {
       wooden_box$set_in_motion(
-        dirX = 1,
-        dirY = 0,
+        dir_x = 1,
+        dir_y = 0,
         speed = 350,
-        distance = 50
+        distance = 50,
+        lag = 0
       )
     },
     input = input
   )
   game$add_overlap(
-    object_one_name = "bear",
-    group_name = "apples",
+    object_one = "bear",
+    group = "apples",
     callback_fun = function(evt) {
       points <<- points + 1
       points_text$set(paste0("points: ", points))

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -53,7 +53,7 @@ server <- function(input, output, session) {
     directions = c("left", "right"),
     speed = 300
   )
-  bear$follow_camera(lerp_x = 0.1, lerp_y = 0.1)
+  bear$follow_camera()
 
   game$add_control(
     "Space",

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -55,9 +55,14 @@ function initPhaserGame(containerId, config) {
           const sprite = this.children.getByName(name);
           if (!sprite) return;
 
-          sprite.body.setVelocity(0);
-
           const { speed, directionMap } = opts;
+
+          if (directionMap.left || directionMap.right) {
+            sprite.body.setVelocityX(0);
+          }
+          if (directionMap.up || directionMap.down) {
+            sprite.body.setVelocityY(0);
+          }
 
           let targetAnim = name + '_idle';
 

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -5,6 +5,7 @@ window.GameBridge = window.GameBridge || {};
 GameBridge.playerControls = {};
 GameBridge.overlapEndWatchers = {};
 GameBridge.forcedAnimations = GameBridge.forcedAnimations || {};
+GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
 
 function playIfChanged(sprite, animKey) {
   if (!sprite || !animKey) return;
@@ -132,12 +133,18 @@ function addPlayerControls(name, directions, speed) {
   };
 };
 
+function setWorldBounds(width, height) {
+  if (!scene || !scene.physics || !scene.cameras) return;
+
+  scene.physics.world.setBounds(0, 0, width, height);
+  scene.cameras.main.setBounds(0, 0, width, height);
+}
+
 function followSpriteWithCamera(name, lerpX = 1, lerpY = 1, roundPixels = true) {
+  GameBridge.pendingCameraFollow[name] = { lerpX, lerpY, roundPixels };
+
   const sprite = scene && scene.children.getByName(name);
-  if (!sprite) {
-    console.warn(`followSpriteWithCamera(): sprite "${name}" not found`);
-    return;
-  }
+  if (!sprite) return;
 
   scene.cameras.main.startFollow(sprite, roundPixels, lerpX, lerpY);
 }
@@ -146,6 +153,7 @@ function stopCameraFollow(name) {
   const camera = scene && scene.cameras && scene.cameras.main;
   if (!camera) return;
 
+  delete GameBridge.pendingCameraFollow[name];
   camera.stopFollow();
 }
 

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -53,6 +53,7 @@ function initPhaserGame(containerId, config) {
   }
 
   function update(time, delta) {
+      applyPendingCameraFollows();
 
       Object.entries(GameBridge.playerControls).forEach(([name, opts]) => {
           const sprite = this.children.getByName(name);
@@ -147,13 +148,26 @@ function setWorldBounds(width, height) {
   applyWorldBounds(GameBridge.pendingWorldBounds);
 }
 
+function applyPendingCameraFollows() {
+  if (!scene || !scene.cameras) return;
+
+  Object.entries(GameBridge.pendingCameraFollow).forEach(([name, followOpts]) => {
+    const sprite = scene.children.getByName(name);
+    if (!sprite || followOpts.applied) return;
+
+    scene.cameras.main.startFollow(
+      sprite,
+      followOpts.roundPixels,
+      followOpts.lerpX,
+      followOpts.lerpY
+    );
+    followOpts.applied = true;
+  });
+}
+
 function followSpriteWithCamera(name, lerpX = 1, lerpY = 1, roundPixels = true) {
-  GameBridge.pendingCameraFollow[name] = { lerpX, lerpY, roundPixels };
-
-  const sprite = scene && scene.children.getByName(name);
-  if (!sprite) return;
-
-  scene.cameras.main.startFollow(sprite, roundPixels, lerpX, lerpY);
+  GameBridge.pendingCameraFollow[name] = { lerpX, lerpY, roundPixels, applied: false };
+  applyPendingCameraFollows();
 }
 
 function stopCameraFollow(name) {

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -6,6 +6,7 @@ GameBridge.playerControls = {};
 GameBridge.overlapEndWatchers = {};
 GameBridge.forcedAnimations = GameBridge.forcedAnimations || {};
 GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
+GameBridge.pendingWorldBounds = GameBridge.pendingWorldBounds || null;
 
 function playIfChanged(sprite, animKey) {
   if (!sprite || !animKey) return;
@@ -48,6 +49,7 @@ function initPhaserGame(containerId, config) {
 
   function create() {
     cursors = this.input.keyboard.createCursorKeys();
+    applyWorldBounds(GameBridge.pendingWorldBounds);
   }
 
   function update(time, delta) {
@@ -133,11 +135,16 @@ function addPlayerControls(name, directions, speed) {
   };
 };
 
-function setWorldBounds(width, height) {
-  if (!scene || !scene.physics || !scene.cameras) return;
+function applyWorldBounds(bounds) {
+  if (!bounds || !scene || !scene.physics || !scene.cameras) return;
 
-  scene.physics.world.setBounds(0, 0, width, height);
-  scene.cameras.main.setBounds(0, 0, width, height);
+  scene.physics.world.setBounds(0, 0, bounds.width, bounds.height);
+  scene.cameras.main.setBounds(0, 0, bounds.width, bounds.height);
+}
+
+function setWorldBounds(width, height) {
+  GameBridge.pendingWorldBounds = { width, height };
+  applyWorldBounds(GameBridge.pendingWorldBounds);
 }
 
 function followSpriteWithCamera(name, lerpX = 1, lerpY = 1, roundPixels = true) {

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -1,6 +1,7 @@
 window.GameBridge = window.GameBridge || {};
 GameBridge.keyControlHandlers = GameBridge.keyControlHandlers || {};
 GameBridge.forcedAnimations = GameBridge.forcedAnimations || {};
+GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
 
 
 function resolveFrameCount(textureKey, frameWidth, frameHeight, frameCount) {
@@ -44,6 +45,16 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
     sprite.play(name + '_idle');
 
     scene[name] = sprite;
+
+    const followOpts = GameBridge.pendingCameraFollow[name];
+    if (followOpts) {
+      scene.cameras.main.startFollow(
+        sprite,
+        followOpts.roundPixels,
+        followOpts.lerpX,
+        followOpts.lerpY
+      );
+    }
   });
 
   scene.load.start();

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -46,14 +46,8 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
 
     scene[name] = sprite;
 
-    const followOpts = GameBridge.pendingCameraFollow[name];
-    if (followOpts) {
-      scene.cameras.main.startFollow(
-        sprite,
-        followOpts.roundPixels,
-        followOpts.lerpX,
-        followOpts.lerpY
-      );
+    if (typeof applyPendingCameraFollows === "function") {
+      applyPendingCameraFollows();
     }
   });
 

--- a/man/PhaserGame.Rd
+++ b/man/PhaserGame.Rd
@@ -38,6 +38,7 @@ game <- PhaserGame$new(id = "my_game", width = 1024, height = 768)
 \item \href{#method-PhaserGame-add_rectangle}{\code{PhaserGame$add_rectangle()}}
 \item \href{#method-PhaserGame-add_image}{\code{PhaserGame$add_image()}}
 \item \href{#method-PhaserGame-add_map}{\code{PhaserGame$add_map()}}
+\item \href{#method-PhaserGame-set_world_bounds}{\code{PhaserGame$set_world_bounds()}}
 \item \href{#method-PhaserGame-enable_terrain_collision}{\code{PhaserGame$enable_terrain_collision()}}
 \item \href{#method-PhaserGame-add_sprite}{\code{PhaserGame$add_sprite()}}
 \item \href{#method-PhaserGame-add_group}{\code{PhaserGame$add_group()}}
@@ -236,6 +237,28 @@ Add a background (tilemap) layer from Tiled JSON + tileset image(s).
 \item{\code{tileset_names}}{Character vector. Names of tilesets as defined in Tiled.}
 
 \item{\code{layer_name}}{Character. Name of the layer to render from Tiled.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Invisible; sends a custom message to the client.
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-PhaserGame-set_world_bounds"></a>}}
+\if{latex}{\out{\hypertarget{method-PhaserGame-set_world_bounds}{}}}
+\subsection{Method \code{set_world_bounds()}}{
+Set the Phaser physics world and camera bounds.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$set_world_bounds(width, height)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{width}}{Numeric. World width in pixels.}
+
+\item{\code{height}}{Numeric. World height in pixels.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -106,6 +106,16 @@ test_that("sample app and hedgehog assets are available", {
   expect_true(file.exists(system.file("assets", "hedgehog", "terrain", "grass.png", package = "shinyphaser")))
 })
 
+test_that("PhaserGame set_world_bounds sends expected JS", {
+  session <- make_mock_session()
+  game <- PhaserGame$new()
+  game$set_shiny_session(session)
+  game$set_world_bounds(width = 1600, height = 800)
+
+  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
+  expect_true(any(grepl("setWorldBounds\\(1600, 800\\);", msgs)))
+})
+
 test_that("PhaserGame exposes use_phaser UI initializer", {
   game <- PhaserGame$new()
 


### PR DESCRIPTION
### Motivation

* Add a new arcade-style example game (bear) to demonstrate player controls, collisions, and text UI. 
* Align the example with recent API parameter renames and asset path reorganizations so the example works with the current package API. 
* Improve the Phaser update loop so sprite velocities are cleared per axis to support independent X/Y motion (e.g., jumping while moving). 

### Description

* Add and modify `inst/examples/bear.R` to register the example with `game$use_phaser()`, update asset paths (from `assets/bear_game/...` to `assets/bear/...`), and adjust coordinates and gravity for the scene. 
* Update sprite and animation constructor calls to use snake_case parameter names such as `frame_width`, `frame_height`, and `frame_rate`, and replace legacy motion calls with `set_velocity_y` and `set_gravity` usages. 
* Update collider/overlap call signatures in the example to use `object_one`, `object_two`, and `group` parameter names and rename motion direction params to `dir_x`/`dir_y`, adding a `lag` argument where appropriate. 
* Change `inst/www/phaser-game.js` `update` logic to clear velocities per axis (`setVelocityX(0)`/`setVelocityY(0)`) only when that axis is controlled, instead of calling `setVelocity(0)` for both axes. 
* Update `NEWS.md` to announce the new arcade example. 

### Testing

* Ran package unit tests via `devtools::test()` and they completed without failures. 
* Performed a package check with `R CMD check --no-manual` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fcff9f2e8832f8ea84a813ec70582)