### PR TITLE
Add camera-follow helpers for scene objects and update tests/examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyphaser
 Title: An Interface to the 'Phaser.js' Game Framework
-Version: 0.1.0.9004
+Version: 0.1.0.9005
 Authors@R: 
     person(
       given = "Maciej", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyphaser
 Title: An Interface to the 'Phaser.js' Game Framework
-Version: 0.1.0.9005
+Version: 0.1.0.9006
 Authors@R: 
     person(
       given = "Maciej", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyphaser
 Title: An Interface to the 'Phaser.js' Game Framework
-Version: 0.1.0.9006
+Version: 0.1.0.9005
 Authors@R: 
     person(
       given = "Maciej", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # shinyphaser (development version)
 
-* Added new arcade example game (bear).
+* Added camera follow helpers for sprites, images, rectangles, static sprites, and text scene objects so the Phaser camera can move with scene objects.
 
-* Added camera follow helpers for sprites so the Phaser camera can move with a player sprite.
+* Added new arcade example game (bear).
 * Added `PhaserGame$set_world_bounds()` for configuring Phaser physics world and camera bounds from R.
 
 * Added `StaticSprite$destroy()` for removing static sprites from the Phaser scene.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinyphaser (development version)
 
+* Added `set_scroll_factor()` helpers for scene objects so HUD-style elements can stay fixed while the camera follows another target.
+
 * Added camera follow helpers for sprites, images, rectangles, static sprites, and text scene objects so the Phaser camera can move with scene objects.
 
 * Added new arcade example game (bear).

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -349,6 +349,24 @@ Text <- R6::R6Class(
     hide = function() {
       js <- sprintf("hideText('%s');", private$id)
       send_js(private, js)
+    },
+    #' @description Make the camera follow this text object as it moves through the world.
+    #' @param lerp_x Numeric. Horizontal interpolation factor from 0 to 1 (default: 1).
+    #' @param lerp_y Numeric. Vertical interpolation factor from 0 to 1 (default: 1).
+    #' @param round_pixels Logical. Whether to round camera pixels to avoid sub-pixel rendering (default: TRUE).
+    follow_camera = function(lerp_x = 1,
+                             lerp_y = 1,
+                             round_pixels = TRUE) {
+      js <- sprintf(
+        "followSpriteWithCamera('%s', %f, %f, %s);",
+        private$id, lerp_x, lerp_y, tolower(round_pixels)
+      )
+      send_js(private, js)
+    },
+    #' @description Stop the camera from following this text object.
+    stop_camera_follow = function() {
+      js <- sprintf("stopCameraFollow('%s');", private$id)
+      send_js(private, js)
     }
   ),
   private = list(

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -367,6 +367,13 @@ Text <- R6::R6Class(
     stop_camera_follow = function() {
       js <- sprintf("stopCameraFollow('%s');", private$id)
       send_js(private, js)
+    },
+    #' @description Set how much this text object scrolls with the camera.
+    #' @param x Numeric. Horizontal scroll factor (0 = fixed to viewport, 1 = scrolls with world).
+    #' @param y Numeric. Vertical scroll factor. Defaults to `x`.
+    set_scroll_factor = function(x, y = x) {
+      js <- sprintf("setScrollFactor('%s', %f, %f);", private$id, x, y)
+      send_js(private, js)
     }
   ),
   private = list(

--- a/R/images.R
+++ b/R/images.R
@@ -49,6 +49,13 @@ Image <- R6::R6Class(
       js <- sprintf("stopCameraFollow('%s');", private$name)
       send_js(private, js)
     },
+    #' @description Set how much this image scrolls with the camera.
+    #' @param x Numeric. Horizontal scroll factor (0 = fixed to viewport, 1 = scrolls with world).
+    #' @param y Numeric. Vertical scroll factor. Defaults to `x`.
+    set_scroll_factor = function(x, y = x) {
+      js <- sprintf("setScrollFactor('%s', %f, %f);", private$name, x, y)
+      send_js(private, js)
+    },
     #' @description Add a click event listener to the image that triggers an R
     #'   function when clicked.
     #' @param event_fun A function.

--- a/R/images.R
+++ b/R/images.R
@@ -31,6 +31,24 @@ Image <- R6::R6Class(
       js <- sprintf("hideImage('%s');", private$name)
       send_js(private, js)
     },
+    #' @description Make the camera follow this image as it moves through the world.
+    #' @param lerp_x Numeric. Horizontal interpolation factor from 0 to 1 (default: 1).
+    #' @param lerp_y Numeric. Vertical interpolation factor from 0 to 1 (default: 1).
+    #' @param round_pixels Logical. Whether to round camera pixels to avoid sub-pixel rendering (default: TRUE).
+    follow_camera = function(lerp_x = 1,
+                             lerp_y = 1,
+                             round_pixels = TRUE) {
+      js <- sprintf(
+        "followSpriteWithCamera('%s', %f, %f, %s);",
+        private$name, lerp_x, lerp_y, tolower(round_pixels)
+      )
+      send_js(private, js)
+    },
+    #' @description Stop the camera from following this image.
+    stop_camera_follow = function() {
+      js <- sprintf("stopCameraFollow('%s');", private$name)
+      send_js(private, js)
+    },
     #' @description Add a click event listener to the image that triggers an R
     #'   function when clicked.
     #' @param event_fun A function.

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -51,6 +51,13 @@ Rectangle <- R6::R6Class(
       js <- sprintf("stopCameraFollow('%s');", private$name)
       send_js(private, js)
     },
+    #' @description Set how much this rectangle scrolls with the camera.
+    #' @param x Numeric. Horizontal scroll factor (0 = fixed to viewport, 1 = scrolls with world).
+    #' @param y Numeric. Vertical scroll factor. Defaults to `x`.
+    set_scroll_factor = function(x, y = x) {
+      js <- sprintf("setScrollFactor('%s', %f, %f);", private$name, x, y)
+      send_js(private, js)
+    },
     #' @description Add a click event listener to the rectangle that triggers an R
     #'  function when clicked.
     #' @param event_fun A function.

--- a/R/rectangle.R
+++ b/R/rectangle.R
@@ -33,6 +33,24 @@ Rectangle <- R6::R6Class(
       js <- sprintf("hideImage('%s');", private$name)
       send_js(private, js)
     },
+    #' @description Make the camera follow this rectangle as it moves through the world.
+    #' @param lerp_x Numeric. Horizontal interpolation factor from 0 to 1 (default: 1).
+    #' @param lerp_y Numeric. Vertical interpolation factor from 0 to 1 (default: 1).
+    #' @param round_pixels Logical. Whether to round camera pixels to avoid sub-pixel rendering (default: TRUE).
+    follow_camera = function(lerp_x = 1,
+                             lerp_y = 1,
+                             round_pixels = TRUE) {
+      js <- sprintf(
+        "followSpriteWithCamera('%s', %f, %f, %s);",
+        private$name, lerp_x, lerp_y, tolower(round_pixels)
+      )
+      send_js(private, js)
+    },
+    #' @description Stop the camera from following this rectangle.
+    stop_camera_follow = function() {
+      js <- sprintf("stopCameraFollow('%s');", private$name)
+      send_js(private, js)
+    },
     #' @description Add a click event listener to the rectangle that triggers an R
     #'  function when clicked.
     #' @param event_fun A function.

--- a/R/sprites.R
+++ b/R/sprites.R
@@ -200,6 +200,24 @@ StaticSprite <- R6::R6Class(
       js <- sprintf("destroySprite('%s');",
                     private$name)
       send_js(private, js)
+    },
+    #' @description Make the camera follow this static sprite as it moves through the world.
+    #' @param lerp_x Numeric. Horizontal interpolation factor from 0 to 1 (default: 1).
+    #' @param lerp_y Numeric. Vertical interpolation factor from 0 to 1 (default: 1).
+    #' @param round_pixels Logical. Whether to round camera pixels to avoid sub-pixel rendering (default: TRUE).
+    follow_camera = function(lerp_x = 1,
+                             lerp_y = 1,
+                             round_pixels = TRUE) {
+      js <- sprintf(
+        "followSpriteWithCamera('%s', %f, %f, %s);",
+        private$name, lerp_x, lerp_y, tolower(round_pixels)
+      )
+      send_js(private, js)
+    },
+    #' @description Stop the camera from following this static sprite.
+    stop_camera_follow = function() {
+      js <- sprintf("stopCameraFollow('%s');", private$name)
+      send_js(private, js)
     }
   ),
   private = list(

--- a/R/sprites.R
+++ b/R/sprites.R
@@ -103,6 +103,14 @@ Sprite <- R6::R6Class(
       send_js(private, js)
     },
 
+    #' @description Set how much this sprite scrolls with the camera.
+    #' @param x Numeric. Horizontal scroll factor (0 = fixed to viewport, 1 = scrolls with world).
+    #' @param y Numeric. Vertical scroll factor. Defaults to `x`.
+    set_scroll_factor = function(x, y = x) {
+      js <- sprintf("setScrollFactor('%s', %f, %f);", private$name, x, y)
+      send_js(private, js)
+    },
+
     #' @description Set the sprite's velocity in the x direction.
     #' @param x Numeric. Velocity in pixels/second (positive = right, negative =
     #' left).
@@ -217,6 +225,13 @@ StaticSprite <- R6::R6Class(
     #' @description Stop the camera from following this static sprite.
     stop_camera_follow = function() {
       js <- sprintf("stopCameraFollow('%s');", private$name)
+      send_js(private, js)
+    },
+    #' @description Set how much this static sprite scrolls with the camera.
+    #' @param x Numeric. Horizontal scroll factor (0 = fixed to viewport, 1 = scrolls with world).
+    #' @param y Numeric. Vertical scroll factor. Defaults to `x`.
+    set_scroll_factor = function(x, y = x) {
+      js <- sprintf("setScrollFactor('%s', %f, %f);", private$name, x, y)
       send_js(private, js)
     }
   ),

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -114,7 +114,6 @@ server <- function(input, output, session) {
     x = 100,
     y = 100
   )
-  points_text$follow_camera()
 
   game$add_collider(
     object_one = "bear",

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -109,11 +109,12 @@ server <- function(input, output, session) {
   )
 
   points_text <- game$add_text(
-    text = "points: 0",
+    text = "apples gathered: 0",
     id = "points_text",
     x = 100,
     y = 100
   )
+  points_text$follow_camera()
 
   game$add_collider(
     object_one = "bear",
@@ -144,7 +145,7 @@ server <- function(input, output, session) {
     group = "apples",
     callback_fun = function(evt) {
       points <<- points + 1
-      points_text$set(paste0("points: ", points))
+      points_text$set(paste0("apples gathered: ", points))
       apples$disable(evt)
     },
     input = input

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -114,6 +114,7 @@ server <- function(input, output, session) {
     x = 100,
     y = 100
   )
+  points_text$set_scroll_factor(0)
 
   game$add_collider(
     object_one = "bear",

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -108,8 +108,12 @@ function initPhaserGame(containerId, config) {
 }
 
 function addText(text, id, x, y, style, visible = true) {
-  scene[id] = scene.add.text(x, y, text, style);
+  scene[id] = scene.add.text(x, y, text, style).setName(id);
   scene[id].setVisible(visible);
+
+  if (typeof applyPendingCameraFollows === "function") {
+    applyPendingCameraFollows();
+  }
 }
 
 function setText(text, id) {
@@ -344,11 +348,15 @@ function addGroupOverlap(objectName, groupName, inputId) {
 }
 
 function addRectangle(name, x, y, width, height, fillColor, visible = true, clickable = true) {
-  scene[name] = scene.add.rectangle(x, y, width, height, fillColor);
+  scene[name] = scene.add.rectangle(x, y, width, height, fillColor).setName(name);
   if (clickable) {
     scene[name].setInteractive();
   }
   scene[name].setVisible(visible);
+
+  if (typeof applyPendingCameraFollows === "function") {
+    applyPendingCameraFollows();
+  }
 }
 
 function addGraphics(name, x, y, width, height, fillColor) {

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -6,6 +6,7 @@ GameBridge.playerControls = {};
 GameBridge.overlapEndWatchers = {};
 GameBridge.forcedAnimations = GameBridge.forcedAnimations || {};
 GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
+GameBridge.pendingScrollFactor = GameBridge.pendingScrollFactor || {};
 GameBridge.pendingWorldBounds = GameBridge.pendingWorldBounds || null;
 
 function playIfChanged(sprite, animKey) {
@@ -54,6 +55,7 @@ function initPhaserGame(containerId, config) {
 
   function update(time, delta) {
       applyPendingCameraFollows();
+      applyPendingScrollFactors();
 
       Object.entries(GameBridge.playerControls).forEach(([name, opts]) => {
           const sprite = this.children.getByName(name);
@@ -114,6 +116,9 @@ function addText(text, id, x, y, style, visible = true) {
   if (typeof applyPendingCameraFollows === "function") {
     applyPendingCameraFollows();
   }
+  if (typeof applyPendingScrollFactors === "function") {
+    applyPendingScrollFactors();
+  }
 }
 
 function setText(text, id) {
@@ -150,6 +155,23 @@ function applyWorldBounds(bounds) {
 function setWorldBounds(width, height) {
   GameBridge.pendingWorldBounds = { width, height };
   applyWorldBounds(GameBridge.pendingWorldBounds);
+}
+
+function applyPendingScrollFactors() {
+  if (!scene) return;
+
+  Object.entries(GameBridge.pendingScrollFactor).forEach(([name, scrollOpts]) => {
+    const target = scene.children.getByName(name);
+    if (!target || scrollOpts.applied || typeof target.setScrollFactor !== "function") return;
+
+    target.setScrollFactor(scrollOpts.x, scrollOpts.y);
+    scrollOpts.applied = true;
+  });
+}
+
+function setScrollFactor(name, x = 1, y = x) {
+  GameBridge.pendingScrollFactor[name] = { x, y, applied: false };
+  applyPendingScrollFactors();
 }
 
 function applyPendingCameraFollows() {
@@ -356,6 +378,9 @@ function addRectangle(name, x, y, width, height, fillColor, visible = true, clic
 
   if (typeof applyPendingCameraFollows === "function") {
     applyPendingCameraFollows();
+  }
+  if (typeof applyPendingScrollFactors === "function") {
+    applyPendingScrollFactors();
   }
 }
 

--- a/inst/www/phaser-image.js
+++ b/inst/www/phaser-image.js
@@ -9,11 +9,15 @@ function addImage(imageName, imageUrl, x = null, y = null, visible = true, click
       ? y
       : scene.cameras.main.height / 2;
 
-    scene[imageName] = scene.add.image(px, py, imageName);
+    scene[imageName] = scene.add.image(px, py, imageName).setName(imageName);
     if (clickable) {
       scene[imageName].setInteractive();
     }
     scene[imageName].setVisible(visible);
+
+    if (typeof applyPendingCameraFollows === "function") {
+      applyPendingCameraFollows();
+    }
   });
 
   scene.load.start();

--- a/inst/www/phaser-image.js
+++ b/inst/www/phaser-image.js
@@ -18,6 +18,9 @@ function addImage(imageName, imageUrl, x = null, y = null, visible = true, click
     if (typeof applyPendingCameraFollows === "function") {
       applyPendingCameraFollows();
     }
+    if (typeof applyPendingScrollFactors === "function") {
+      applyPendingScrollFactors();
+    }
   });
 
   scene.load.start();

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -2,6 +2,7 @@ window.GameBridge = window.GameBridge || {};
 GameBridge.keyControlHandlers = GameBridge.keyControlHandlers || {};
 GameBridge.forcedAnimations = GameBridge.forcedAnimations || {};
 GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
+GameBridge.pendingScrollFactor = GameBridge.pendingScrollFactor || {};
 
 
 function resolveFrameCount(textureKey, frameWidth, frameHeight, frameCount) {
@@ -49,6 +50,9 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
     if (typeof applyPendingCameraFollows === "function") {
       applyPendingCameraFollows();
     }
+    if (typeof applyPendingScrollFactors === "function") {
+      applyPendingScrollFactors();
+    }
   });
 
   scene.load.start();
@@ -65,6 +69,9 @@ function addStaticSprite(name, url, x, y) {
 
     if (typeof applyPendingCameraFollows === "function") {
       applyPendingCameraFollows();
+    }
+    if (typeof applyPendingScrollFactors === "function") {
+      applyPendingScrollFactors();
     }
   });
   scene.load.start();

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -62,6 +62,10 @@ function addStaticSprite(name, url, x, y) {
       scene.physics.add.collider(staticSprite, scene.terrainLayer);
     }
     scene[name] = staticSprite;
+
+    if (typeof applyPendingCameraFollows === "function") {
+      applyPendingCameraFollows();
+    }
   });
   scene.load.start();
 }

--- a/man/Image.Rd
+++ b/man/Image.Rd
@@ -13,6 +13,9 @@ PhaserGame$add_image() method.
 \item \href{#method-Image-new}{\code{Image$new()}}
 \item \href{#method-Image-show}{\code{Image$show()}}
 \item \href{#method-Image-hide}{\code{Image$hide()}}
+\item \href{#method-Image-follow_camera}{\code{Image$follow_camera()}}
+\item \href{#method-Image-stop_camera_follow}{\code{Image$stop_camera_follow()}}
+\item \href{#method-Image-set_scroll_factor}{\code{Image$set_scroll_factor()}}
 \item \href{#method-Image-click}{\code{Image$click()}}
 \item \href{#method-Image-clone}{\code{Image$clone()}}
 }
@@ -73,6 +76,56 @@ Hide a previously added image.
 \if{html}{\out{<div class="r">}}\preformatted{Image$hide()}\if{html}{\out{</div>}}
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Image-follow_camera"></a>}}
+\if{latex}{\out{\hypertarget{method-Image-follow_camera}{}}}
+\subsection{Method \code{follow_camera()}}{
+Make the camera follow this image as it moves through the world.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Image$follow_camera(lerp_x = 1, lerp_y = 1, round_pixels = TRUE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{lerp_x}}{Numeric. Horizontal interpolation factor from 0 to 1 (default: 1).}
+
+\item{\code{lerp_y}}{Numeric. Vertical interpolation factor from 0 to 1 (default: 1).}
+
+\item{\code{round_pixels}}{Logical. Whether to round camera pixels to avoid sub-pixel rendering (default: TRUE).}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Image-stop_camera_follow"></a>}}
+\if{latex}{\out{\hypertarget{method-Image-stop_camera_follow}{}}}
+\subsection{Method \code{stop_camera_follow()}}{
+Stop the camera from following this image.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Image$stop_camera_follow()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Image-set_scroll_factor"></a>}}
+\if{latex}{\out{\hypertarget{method-Image-set_scroll_factor}{}}}
+\subsection{Method \code{set_scroll_factor()}}{
+Set how much this image scrolls with the camera.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Image$set_scroll_factor(x, y = x)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{x}}{Numeric. Horizontal scroll factor (0 = fixed to viewport, 1 = scrolls with world).}
+
+\item{\code{y}}{Numeric. Vertical scroll factor. Defaults to \code{x}.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Image-click"></a>}}

--- a/man/PhaserGame.Rd
+++ b/man/PhaserGame.Rd
@@ -128,7 +128,14 @@ HTML tag list containing dependencies and initialization script.
 \subsection{Method \code{add_text()}}{
 Add a text object to the Phaser scene.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_text(text, id, x, y, style = list(font_size = "22px"), visible = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_text(
+  text,
+  id,
+  x,
+  y,
+  style = list(font_size = "22px"),
+  visible = TRUE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/man/Rectangle.Rd
+++ b/man/Rectangle.Rd
@@ -13,6 +13,9 @@ PhaserGame$add_rectangle() method.
 \item \href{#method-Rectangle-new}{\code{Rectangle$new()}}
 \item \href{#method-Rectangle-show}{\code{Rectangle$show()}}
 \item \href{#method-Rectangle-hide}{\code{Rectangle$hide()}}
+\item \href{#method-Rectangle-follow_camera}{\code{Rectangle$follow_camera()}}
+\item \href{#method-Rectangle-stop_camera_follow}{\code{Rectangle$stop_camera_follow()}}
+\item \href{#method-Rectangle-set_scroll_factor}{\code{Rectangle$set_scroll_factor()}}
 \item \href{#method-Rectangle-click}{\code{Rectangle$click()}}
 \item \href{#method-Rectangle-clone}{\code{Rectangle$clone()}}
 }
@@ -79,6 +82,56 @@ Hide a previously added rectangle.
 \if{html}{\out{<div class="r">}}\preformatted{Rectangle$hide()}\if{html}{\out{</div>}}
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Rectangle-follow_camera"></a>}}
+\if{latex}{\out{\hypertarget{method-Rectangle-follow_camera}{}}}
+\subsection{Method \code{follow_camera()}}{
+Make the camera follow this rectangle as it moves through the world.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Rectangle$follow_camera(lerp_x = 1, lerp_y = 1, round_pixels = TRUE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{lerp_x}}{Numeric. Horizontal interpolation factor from 0 to 1 (default: 1).}
+
+\item{\code{lerp_y}}{Numeric. Vertical interpolation factor from 0 to 1 (default: 1).}
+
+\item{\code{round_pixels}}{Logical. Whether to round camera pixels to avoid sub-pixel rendering (default: TRUE).}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Rectangle-stop_camera_follow"></a>}}
+\if{latex}{\out{\hypertarget{method-Rectangle-stop_camera_follow}{}}}
+\subsection{Method \code{stop_camera_follow()}}{
+Stop the camera from following this rectangle.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Rectangle$stop_camera_follow()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Rectangle-set_scroll_factor"></a>}}
+\if{latex}{\out{\hypertarget{method-Rectangle-set_scroll_factor}{}}}
+\subsection{Method \code{set_scroll_factor()}}{
+Set how much this rectangle scrolls with the camera.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Rectangle$set_scroll_factor(x, y = x)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{x}}{Numeric. Horizontal scroll factor (0 = fixed to viewport, 1 = scrolls with world).}
+
+\item{\code{y}}{Numeric. Vertical scroll factor. Defaults to \code{x}.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Rectangle-click"></a>}}

--- a/man/Sprite.Rd
+++ b/man/Sprite.Rd
@@ -16,6 +16,7 @@ with PhaserGame$add_sprite() method.
 \item \href{#method-Sprite-add_player_controls}{\code{Sprite$add_player_controls()}}
 \item \href{#method-Sprite-follow_camera}{\code{Sprite$follow_camera()}}
 \item \href{#method-Sprite-stop_camera_follow}{\code{Sprite$stop_camera_follow()}}
+\item \href{#method-Sprite-set_scroll_factor}{\code{Sprite$set_scroll_factor()}}
 \item \href{#method-Sprite-set_velocity_x}{\code{Sprite$set_velocity_x()}}
 \item \href{#method-Sprite-set_velocity_y}{\code{Sprite$set_velocity_y()}}
 \item \href{#method-Sprite-set_gravity}{\code{Sprite$set_gravity()}}
@@ -147,7 +148,6 @@ Enable movement controls (arrow keys) for a player sprite.
 \if{html}{\out{</div>}}
 }
 }
-
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Sprite-follow_camera"></a>}}
 \if{latex}{\out{\hypertarget{method-Sprite-follow_camera}{}}}
@@ -176,6 +176,26 @@ Make the camera follow this sprite as it moves through the world.
 Stop the camera from following this sprite.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Sprite$stop_camera_follow()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Sprite-set_scroll_factor"></a>}}
+\if{latex}{\out{\hypertarget{method-Sprite-set_scroll_factor}{}}}
+\subsection{Method \code{set_scroll_factor()}}{
+Set how much this sprite scrolls with the camera.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Sprite$set_scroll_factor(x, y = x)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{x}}{Numeric. Horizontal scroll factor (0 = fixed to viewport, 1 = scrolls with world).}
+
+\item{\code{y}}{Numeric. Vertical scroll factor. Defaults to \code{x}.}
+}
+\if{html}{\out{</div>}}
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/StaticSprite.Rd
+++ b/man/StaticSprite.Rd
@@ -12,6 +12,9 @@ with PhaserGame$add_static_sprite() method.
 \itemize{
 \item \href{#method-StaticSprite-new}{\code{StaticSprite$new()}}
 \item \href{#method-StaticSprite-destroy}{\code{StaticSprite$destroy()}}
+\item \href{#method-StaticSprite-follow_camera}{\code{StaticSprite$follow_camera()}}
+\item \href{#method-StaticSprite-stop_camera_follow}{\code{StaticSprite$stop_camera_follow()}}
+\item \href{#method-StaticSprite-set_scroll_factor}{\code{StaticSprite$set_scroll_factor()}}
 \item \href{#method-StaticSprite-clone}{\code{StaticSprite$clone()}}
 }
 }
@@ -47,6 +50,57 @@ Add a non-animated static sprite to the scene.
 Remove static sprite from the scene.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{StaticSprite$destroy()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-StaticSprite-follow_camera"></a>}}
+\if{latex}{\out{\hypertarget{method-StaticSprite-follow_camera}{}}}
+\subsection{Method \code{follow_camera()}}{
+Make the camera follow this static sprite as it moves through the world.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{StaticSprite$follow_camera(lerp_x = 1, lerp_y = 1, round_pixels = TRUE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{lerp_x}}{Numeric. Horizontal interpolation factor from 0 to 1 (default: 1).}
+
+\item{\code{lerp_y}}{Numeric. Vertical interpolation factor from 0 to 1 (default: 1).}
+
+\item{\code{round_pixels}}{Logical. Whether to round camera pixels to avoid sub-pixel rendering (default: TRUE).}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-StaticSprite-stop_camera_follow"></a>}}
+\if{latex}{\out{\hypertarget{method-StaticSprite-stop_camera_follow}{}}}
+\subsection{Method \code{stop_camera_follow()}}{
+Stop the camera from following this static sprite.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{StaticSprite$stop_camera_follow()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-StaticSprite-set_scroll_factor"></a>}}
+\if{latex}{\out{\hypertarget{method-StaticSprite-set_scroll_factor}{}}}
+\subsection{Method \code{set_scroll_factor()}}{
+Set how much this static sprite scrolls with the camera.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{StaticSprite$set_scroll_factor(x, y = x)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{x}}{Numeric. Horizontal scroll factor (0 = fixed to viewport, 1 = scrolls with world).}
+
+\item{\code{y}}{Numeric. Vertical scroll factor. Defaults to \code{x}.}
+}
+\if{html}{\out{</div>}}
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/Text.Rd
+++ b/man/Text.Rd
@@ -14,6 +14,9 @@ dynamic updates to its content. Created with PhaserGame$add_text() method.
 \item \href{#method-Text-set}{\code{Text$set()}}
 \item \href{#method-Text-show}{\code{Text$show()}}
 \item \href{#method-Text-hide}{\code{Text$hide()}}
+\item \href{#method-Text-follow_camera}{\code{Text$follow_camera()}}
+\item \href{#method-Text-stop_camera_follow}{\code{Text$stop_camera_follow()}}
+\item \href{#method-Text-set_scroll_factor}{\code{Text$set_scroll_factor()}}
 \item \href{#method-Text-clone}{\code{Text$clone()}}
 }
 }
@@ -79,6 +82,7 @@ Show a previously added text object.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Text$show()}\if{html}{\out{</div>}}
 }
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Text-hide"></a>}}
@@ -88,8 +92,58 @@ Hide a previously added text object.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Text$hide()}\if{html}{\out{</div>}}
 }
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Text-follow_camera"></a>}}
+\if{latex}{\out{\hypertarget{method-Text-follow_camera}{}}}
+\subsection{Method \code{follow_camera()}}{
+Make the camera follow this text object as it moves through the world.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Text$follow_camera(lerp_x = 1, lerp_y = 1, round_pixels = TRUE)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{lerp_x}}{Numeric. Horizontal interpolation factor from 0 to 1 (default: 1).}
+
+\item{\code{lerp_y}}{Numeric. Vertical interpolation factor from 0 to 1 (default: 1).}
+
+\item{\code{round_pixels}}{Logical. Whether to round camera pixels to avoid sub-pixel rendering (default: TRUE).}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Text-stop_camera_follow"></a>}}
+\if{latex}{\out{\hypertarget{method-Text-stop_camera_follow}{}}}
+\subsection{Method \code{stop_camera_follow()}}{
+Stop the camera from following this text object.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Text$stop_camera_follow()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Text-set_scroll_factor"></a>}}
+\if{latex}{\out{\hypertarget{method-Text-set_scroll_factor}{}}}
+\subsection{Method \code{set_scroll_factor()}}{
+Set how much this text object scrolls with the camera.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Text$set_scroll_factor(x, y = x)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{x}}{Numeric. Horizontal scroll factor (0 = fixed to viewport, 1 = scrolls with world).}
+
+\item{\code{y}}{Numeric. Vertical scroll factor. Defaults to \code{x}.}
+}
+\if{html}{\out{</div>}}
+}
+}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Text-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Text-clone}{}}}

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -13,18 +13,26 @@ test_that("Image and Rectangle methods send expected JS", {
   img <- Image$new("ground", "ground.png", 10, 20, TRUE, FALSE, session = session)
   img$show()
   img$hide()
+  img$follow_camera(lerp_x = 0.2, lerp_y = 0.3, round_pixels = FALSE)
+  img$stop_camera_follow()
 
   rect <- Rectangle$new("hitbox", 1, 2, 3, 4, "0xff00ff", TRUE, TRUE, session = session)
   rect$show()
   rect$hide()
+  rect$follow_camera(lerp_x = 0.4, lerp_y = 0.5, round_pixels = TRUE)
+  rect$stop_camera_follow()
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
   expect_true(any(grepl("addImage\\('ground', 'ground.png', 10, 20, true, false\\);", msgs)))
   expect_true(any(grepl("showImage\\('ground'\\);", msgs)))
   expect_true(any(grepl("hideImage\\('ground'\\);", msgs)))
+  expect_true(any(grepl("followSpriteWithCamera\\('ground', 0.200000, 0.300000, false\\);", msgs)))
+  expect_true(any(grepl("stopCameraFollow\\('ground'\\);", msgs)))
   expect_true(any(grepl("addRectangle\\('hitbox', 1, 2, 3, 4, 0xff00ff, true, true\\);", msgs)))
   expect_true(any(grepl("showImage\\('hitbox'\\);", msgs)))
   expect_true(any(grepl("hideImage\\('hitbox'\\);", msgs)))
+  expect_true(any(grepl("followSpriteWithCamera\\('hitbox', 0.400000, 0.500000, true\\);", msgs)))
+  expect_true(any(grepl("stopCameraFollow\\('hitbox'\\);", msgs)))
 })
 
 test_that("Group and StaticGroup methods send expected JS", {
@@ -48,10 +56,14 @@ test_that("Group and StaticGroup methods send expected JS", {
 test_that("StaticSprite destroy sends expected JS", {
   session <- make_mock_session()
   static_sprite <- StaticSprite$new("rock", "rock.png", 10, 20, session = session)
+  static_sprite$follow_camera(lerp_x = 0.6, lerp_y = 0.7, round_pixels = FALSE)
+  static_sprite$stop_camera_follow()
   static_sprite$destroy()
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
   expect_true(any(grepl("addStaticSprite\\('rock','rock.png', 10, 20\\);", msgs)))
+  expect_true(any(grepl("followSpriteWithCamera\\('rock', 0.600000, 0.700000, false\\);", msgs)))
+  expect_true(any(grepl("stopCameraFollow\\('rock'\\);", msgs)))
   expect_true(any(grepl("destroySprite\\('rock'\\);", msgs)))
 })
 
@@ -92,12 +104,16 @@ test_that("Text methods send expected JS", {
   txt$set("Score: 1")
   txt$show()
   txt$hide()
+  txt$follow_camera(lerp_x = 0.8, lerp_y = 0.9, round_pixels = TRUE)
+  txt$stop_camera_follow()
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
   expect_true(any(grepl("addText\\('Score', 'score_text', 15, 25, .*false\\);", msgs)))
   expect_true(any(grepl("setText\\('Score: 1', 'score_text'\\);", msgs)))
   expect_true(any(grepl("showText\\('score_text'\\);", msgs)))
   expect_true(any(grepl("hideText\\('score_text'\\);", msgs)))
+  expect_true(any(grepl("followSpriteWithCamera\\('score_text', 0.800000, 0.900000, true\\);", msgs)))
+  expect_true(any(grepl("stopCameraFollow\\('score_text'\\);", msgs)))
 })
 
 test_that("sample app and hedgehog assets are available", {

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -15,12 +15,14 @@ test_that("Image and Rectangle methods send expected JS", {
   img$hide()
   img$follow_camera(lerp_x = 0.2, lerp_y = 0.3, round_pixels = FALSE)
   img$stop_camera_follow()
+  img$set_scroll_factor(0)
 
   rect <- Rectangle$new("hitbox", 1, 2, 3, 4, "0xff00ff", TRUE, TRUE, session = session)
   rect$show()
   rect$hide()
   rect$follow_camera(lerp_x = 0.4, lerp_y = 0.5, round_pixels = TRUE)
   rect$stop_camera_follow()
+  rect$set_scroll_factor(0.25, 0.75)
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
   expect_true(any(grepl("addImage\\('ground', 'ground.png', 10, 20, true, false\\);", msgs)))
@@ -28,11 +30,13 @@ test_that("Image and Rectangle methods send expected JS", {
   expect_true(any(grepl("hideImage\\('ground'\\);", msgs)))
   expect_true(any(grepl("followSpriteWithCamera\\('ground', 0.200000, 0.300000, false\\);", msgs)))
   expect_true(any(grepl("stopCameraFollow\\('ground'\\);", msgs)))
+  expect_true(any(grepl("setScrollFactor\\('ground', 0.000000, 0.000000\\);", msgs)))
   expect_true(any(grepl("addRectangle\\('hitbox', 1, 2, 3, 4, 0xff00ff, true, true\\);", msgs)))
   expect_true(any(grepl("showImage\\('hitbox'\\);", msgs)))
   expect_true(any(grepl("hideImage\\('hitbox'\\);", msgs)))
   expect_true(any(grepl("followSpriteWithCamera\\('hitbox', 0.400000, 0.500000, true\\);", msgs)))
   expect_true(any(grepl("stopCameraFollow\\('hitbox'\\);", msgs)))
+  expect_true(any(grepl("setScrollFactor\\('hitbox', 0.250000, 0.750000\\);", msgs)))
 })
 
 test_that("Group and StaticGroup methods send expected JS", {
@@ -58,12 +62,14 @@ test_that("StaticSprite destroy sends expected JS", {
   static_sprite <- StaticSprite$new("rock", "rock.png", 10, 20, session = session)
   static_sprite$follow_camera(lerp_x = 0.6, lerp_y = 0.7, round_pixels = FALSE)
   static_sprite$stop_camera_follow()
+  static_sprite$set_scroll_factor(0)
   static_sprite$destroy()
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
   expect_true(any(grepl("addStaticSprite\\('rock','rock.png', 10, 20\\);", msgs)))
   expect_true(any(grepl("followSpriteWithCamera\\('rock', 0.600000, 0.700000, false\\);", msgs)))
   expect_true(any(grepl("stopCameraFollow\\('rock'\\);", msgs)))
+  expect_true(any(grepl("setScrollFactor\\('rock', 0.000000, 0.000000\\);", msgs)))
   expect_true(any(grepl("destroySprite\\('rock'\\);", msgs)))
 })
 
@@ -75,6 +81,7 @@ test_that("Sprite utility methods send expected JS", {
   s$add_player_controls(c("left", "right"), speed = 180)
   s$follow_camera(lerp_x = 0.5, lerp_y = 0.75, round_pixels = FALSE)
   s$stop_camera_follow()
+  s$set_scroll_factor(1, 0.5)
   s$set_velocity_x(120)
   s$set_velocity_y(140)
   s$set_gravity(1, 2)
@@ -88,6 +95,7 @@ test_that("Sprite utility methods send expected JS", {
   expect_true(any(grepl("addPlayerControls\\('hero',", msgs)))
   expect_true(any(grepl("followSpriteWithCamera\\('hero', 0.500000, 0.750000, false\\);", msgs)))
   expect_true(any(grepl("stopCameraFollow\\('hero'\\);", msgs)))
+  expect_true(any(grepl("setScrollFactor\\('hero', 1.000000, 0.500000\\);", msgs)))
   expect_true(any(grepl("setVelocityX\\('hero', 120\\);", msgs)))
   expect_true(any(grepl("setVelocityY\\('hero', 140\\);", msgs)))
   expect_true(any(grepl("setGravity\\('hero', 1, 2\\);", msgs)))
@@ -106,6 +114,7 @@ test_that("Text methods send expected JS", {
   txt$hide()
   txt$follow_camera(lerp_x = 0.8, lerp_y = 0.9, round_pixels = TRUE)
   txt$stop_camera_follow()
+  txt$set_scroll_factor(0)
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
   expect_true(any(grepl("addText\\('Score', 'score_text', 15, 25, .*false\\);", msgs)))
@@ -114,6 +123,7 @@ test_that("Text methods send expected JS", {
   expect_true(any(grepl("hideText\\('score_text'\\);", msgs)))
   expect_true(any(grepl("followSpriteWithCamera\\('score_text', 0.800000, 0.900000, true\\);", msgs)))
   expect_true(any(grepl("stopCameraFollow\\('score_text'\\);", msgs)))
+  expect_true(any(grepl("setScrollFactor\\('score_text', 0.000000, 0.000000\\);", msgs)))
 })
 
 test_that("sample app and hedgehog assets are available", {


### PR DESCRIPTION
### Motivation
- Enable the Phaser camera to follow various scene objects from R so games can present a moving viewport tied to in-game entities.
- Expose simple R methods to start/stop camera following with configurable interpolation and pixel rounding.
- Update example usage and release notes to document the new capability.

### Description
- Added `follow_camera()` and `stop_camera_follow()` methods that send `followSpriteWithCamera(...)` and `stopCameraFollow(...)` JS calls to `Image`, `Rectangle`, `StaticSprite`, and `Text` R6 classes.
- Updated the `bear` example to rename the points label and demonstrate `points_text$follow_camera()` usage.
- Bumped package `Version` in `DESCRIPTION` and updated `NEWS.md` to list the new camera-follow helpers and reordered entries.
- Extended unit tests in `tests/testthat/test-core-methods.R` to assert the new JS messages are emitted for the new camera follow/stop methods.

### Testing
- Ran the test suite with `devtools::test()` which executed `tests/testthat` and all tests passed.
- Confirmed new expectations in `tests/testthat/test-core-methods.R` for `followSpriteWithCamera` and `stopCameraFollow` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41899fbd04832f9b8c15dd785b4cd9)