### PR TITLE
Expose cache-busting asset version and disable sample app timer in test mode

### DIFF
--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -53,7 +53,11 @@ PhaserGame <- R6::R6Class(
 
       htmltools::tagList(
         phaser_dependency(),
-        htmltools::tags$div(id = self$id, style = "width:100vw; height:100vh;"),
+        htmltools::tags$div(
+          id = self$id,
+          style = "width:100vw; height:100vh;",
+          `data-shinyphaser-assets` = dependency_version
+        ),
         htmltools::htmlDependency(
           name = "shinyphaser-assets",
           version = dependency_version,

--- a/inst/sample_app/app.R
+++ b/inst/sample_app/app.R
@@ -104,16 +104,18 @@ server <- function(input, output, session) {
     input = input
   )
 
-  shiny::observe({
-    shiny::invalidateLater(700, session)
-    dir <- sample(list(c(-1, 0), c(1, 0), c(0, -1), c(0, 1)), 1)[[1]]
-    enemy$set_in_motion(
-      dir_x = dir[1],
-      dir_y = dir[2],
-      speed = 70,
-      distance = 150,
-      lag = 0
-    )
-  })
+  if (!isTRUE(getOption("shiny.testmode"))) {
+    shiny::observe({
+      shiny::invalidateLater(700, session)
+      dir <- sample(list(c(-1, 0), c(1, 0), c(0, -1), c(0, 1)), 1)[[1]]
+      enemy$set_in_motion(
+        dir_x = dir[1],
+        dir_y = dir[2],
+        speed = 70,
+        distance = 150,
+        lag = 0
+      )
+    })
+  }
 }
 shinyApp(ui, server)


### PR DESCRIPTION
### Motivation
- Ensure `use_phaser()` serializes the cache-busting dependency version into the UI so tests that look for the `shinyphaser-assets` marker and version pattern can pass.
- Prevent background timers in the packaged sample app from running during `shinytest2` startup so the app can reach an idle state for test initialization.

### Description
- Add a `data-shinyphaser-assets` attribute to the Phaser container in `use_phaser()` that carries the computed `dependency_version` so the rendered HTML contains the cache-busting metadata.
- Continue to set the `htmlDependency(..., version = dependency_version)` for the assets so the dependency version and the exposed data attribute remain aligned.
- Wrap the sample app enemy movement observer in `if (!isTRUE(getOption("shiny.testmode"))) { ... }` inside `inst/sample_app/app.R` to disable the repeating `shiny::observe` during test mode.

### Testing
- Ran `git diff --check` to validate the working tree, which succeeded.
- Attempted to run `Rscript -e 'devtools::test(filter = "core-methods|sample_app")'` but the command could not be executed because `Rscript` is not installed in the environment, so package unit tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a440281b7cc832fa8cd047eda83e57a)