### PR TITLE
Record simple overlap callbacks as client actions to run on the client

### DIFF
--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -234,6 +234,14 @@ PhaserGame <- R6::R6Class(
                            input,
                            client_action = NULL) {
       Sys.sleep(0.1)
+      recorded_client_action <- NULL
+      if (is.null(client_action) && !is.null(callback_fun)) {
+        recorded_client_action <- record_client_callback(callback_fun)
+        if (!is.null(recorded_client_action)) {
+          client_action <- recorded_client_action
+        }
+      }
+
       input_id <- paste(
         c("overlap", object_one,
           object_two %||% group),
@@ -255,7 +263,7 @@ PhaserGame <- R6::R6Class(
       }
       send_js(private, js)
 
-      if (!is.null(callback_fun)) {
+      if (!is.null(callback_fun) && is.null(recorded_client_action)) {
         shiny::observeEvent(input[[input_id]], {
           evt <- input[[input_id]]
           callback_fun(evt)
@@ -299,6 +307,14 @@ PhaserGame <- R6::R6Class(
                               input,
                               session = shiny::getDefaultReactiveDomain(),
                               client_action = NULL) {
+     recorded_client_action <- NULL
+     if (is.null(client_action) && !is.null(callback_fun)) {
+       recorded_client_action <- record_client_callback(callback_fun)
+       if (!is.null(recorded_client_action)) {
+         client_action <- recorded_client_action
+       }
+     }
+
      input_id <- paste(
        c("overlap_end", object_one,
          object_two %||% group),
@@ -311,7 +327,7 @@ PhaserGame <- R6::R6Class(
                    jsonlite::toJSON(client_action %||% list(), auto_unbox = TRUE, null = "null"))
      session$sendCustomMessage("phaser", list(js = js))
 
-     if (!is.null(callback_fun)) {
+     if (!is.null(callback_fun) && is.null(recorded_client_action)) {
        shiny::observeEvent(input[[input_id]], {
          evt <- input[[input_id]]
          callback_fun(evt)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,42 @@
 send_js <- function(private, js) {
+  recorder <- getOption("shinyphaser.client_action_recorder", NULL)
+  if (is.function(recorder)) {
+    recorder(js)
+    return(invisible(NULL))
+  }
+
   private$session$sendCustomMessage("phaser", list(js = js))
+}
+
+record_client_callback <- function(callback_fun) {
+  if (is.null(callback_fun)) {
+    return(NULL)
+  }
+
+  body_text <- paste(deparse(body(callback_fun)), collapse = "\n")
+  if (grepl("<<-|\\bif\\b|\\breturn\\b", body_text)) {
+    return(NULL)
+  }
+
+  js_calls <- character()
+  recorder <- function(js) {
+    js_calls <<- c(js_calls, js)
+  }
+
+  old_recorder <- getOption("shinyphaser.client_action_recorder", NULL)
+  options(shinyphaser.client_action_recorder = recorder)
+  on.exit(options(shinyphaser.client_action_recorder = old_recorder), add = TRUE)
+
+  ok <- tryCatch({
+    callback_fun(NULL)
+    TRUE
+  }, error = function(e) {
+    FALSE
+  })
+
+  if (!ok || length(js_calls) == 0) {
+    return(NULL)
+  }
+
+  list(raw_js = js_calls)
 }

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -624,7 +624,17 @@ server <- function(input, output, session) {
           }
         }
       },
-      input = input
+      input = input,
+      client_action = list(
+        set_text = list(
+          id = "combat_status",
+          text = sprintf("%s attacks!", format_enemy_label(skeleton_name))
+        ),
+        sprite = skeleton_name,
+        play_animation = enemy_animation_key(skeleton_name, "attack"),
+        duration = 350,
+        cooldown = enemy_attack_cooldown * 1000
+      )
     )
 
     game$add_overlap_end(

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -474,7 +474,8 @@ server <- function(input, output, session) {
         }
       }
     },
-    input
+    input,
+    client_action = dungeonheroes_space_client_actions(hero_attack_cooldown, enemy_names)
   )
 
   inventory_text <- game$add_text(
@@ -642,6 +643,65 @@ server <- function(input, output, session) {
   }
 
   lapply(enemy_names, add_enemy_handlers)
+}
+
+
+
+dungeonheroes_space_client_actions <- function(hero_attack_cooldown, enemy_names) {
+  enemy_hit_feedback <- lapply(enemy_names, function(enemy_name) {
+    list(
+      set_text = list(
+        id = "combat_status",
+        text = sprintf("You strike %s.", gsub("_", " ", enemy_name))
+      ),
+      when_overlap = c("hero", enemy_name),
+      when_exists = enemy_name
+    )
+  })
+
+  c(
+    list(
+      list(
+        destroy_sprite = "sword",
+        set_text = list(id = "inventory_weapon", text = "weapon: sword"),
+        sprite = "hero",
+        play_animation = "hero_sword",
+        when_overlap = c("hero", "sword"),
+        when_exists = "sword",
+        stop_after_match = TRUE
+      ),
+      list(
+        play_sound = "wizard_laugh",
+        show_alert = list(
+          title = "Dear, oh dear. What are you doing here in these dark forests, lad?",
+          text = "",
+          type = "info"
+        ),
+        when_overlap = c("hero", "wizard"),
+        cooldown = 1000,
+        stop_after_match = TRUE
+      )
+    ),
+    enemy_hit_feedback,
+    list(
+      list(
+        play_sound = "hero_attack",
+        sprite = "hero",
+        play_animation = "hero_attack",
+        duration = 500,
+        cooldown = hero_attack_cooldown * 1000,
+        when_exists = list(name = "sword", exists = TRUE)
+      ),
+      list(
+        play_sound = "hero_attack",
+        sprite = "hero",
+        play_animation = "hero_sword_attack",
+        duration = 500,
+        cooldown = hero_attack_cooldown * 1000,
+        when_exists = list(name = "sword", exists = FALSE)
+      )
+    )
+  )
 }
 
 

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -567,20 +567,23 @@ server <- function(input, output, session) {
   game$add_overlap(
     object_one = "hero",
     object_two = "wizard",
-    callback_fun = function(evt) {
-      talk_bubble_text$show()
-      wizard$play_animation("wizard_talk", duration = 2000)
-    },
-    input = input
+    input = input,
+    client_action = list(
+      show_text = "talk_bubble_text",
+      sprite = "wizard",
+      play_animation = "wizard_talk",
+      duration = 2000
+    )
   )
   game$add_overlap_end(
     object_one = "hero",
     object_two = "wizard",
-    callback_fun = function(evt) {
-      talk_bubble_text$hide()
-      wizard$play_animation("wizard_idle")
-    },
-    input = input
+    input = input,
+    client_action = list(
+      hide_text = "talk_bubble_text",
+      sprite = "wizard",
+      play_animation = "wizard_idle"
+    )
   )
 
   add_enemy_handlers <- function(skeleton_name) {

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -164,9 +164,7 @@ server <- function(input, output, session) {
   }
 
   current_event_overlaps <- function(evt = NULL) {
-    event_overlaps <- as.character(unlist(evt$overlaps %||% character(), use.names = FALSE))
-    tracked_overlaps <- as.character(unlist(input$hero_overlaps$overlaps %||% character(), use.names = FALSE))
-    unique(c(event_overlaps, tracked_overlaps))
+    as.character(unlist(evt$overlaps %||% character(), use.names = FALSE))
   }
 
   nearest_living_enemy <- function(evt = NULL) {
@@ -476,8 +474,7 @@ server <- function(input, output, session) {
         }
       }
     },
-    input,
-    client_action = dungeonheroes_space_client_actions(hero_attack_cooldown, enemy_names)
+    input
   )
 
   inventory_text <- game$add_text(
@@ -570,67 +567,21 @@ server <- function(input, output, session) {
   game$add_overlap(
     object_one = "hero",
     object_two = "wizard",
-    input = input,
-    client_action = list(
-      show_text = "talk_bubble_text",
-      sprite = "wizard",
-      play_animation = "wizard_talk",
-      duration = 2000
-    )
+    callback_fun = function(evt) {
+      talk_bubble_text$show()
+      wizard$play_animation("wizard_talk", duration = 2000)
+    },
+    input = input
   )
   game$add_overlap_end(
     object_one = "hero",
     object_two = "wizard",
-    input = input,
-    client_action = list(
-      hide_text = "talk_bubble_text",
-      sprite = "wizard",
-      play_animation = "wizard_idle"
-    )
+    callback_fun = function(evt) {
+      talk_bubble_text$hide()
+      wizard$play_animation("wizard_idle")
+    },
+    input = input
   )
-
-  shiny::observeEvent(input$hero_overlaps, {
-    if (life_points <= 0) {
-      return()
-    }
-
-    overlapping_enemies <- intersect(current_event_overlaps(input$hero_overlaps), enemy_names)
-    living_overlapping_enemies <- overlapping_enemies[enemy_is_alive[overlapping_enemies]]
-    if (length(living_overlapping_enemies) == 0) {
-      enemy_in_range <<- NULL
-      return()
-    }
-
-    skeleton_name <- living_overlapping_enemies[[1]]
-    enemy_in_range <<- skeleton_name
-
-    current_time <- as.numeric(Sys.time())
-    if ((current_time - enemy_last_attack_time[[skeleton_name]]) < enemy_attack_cooldown) {
-      return()
-    }
-
-    enemy_last_attack_time[skeleton_name] <<- current_time
-    enemies[[skeleton_name]]$play_animation(
-      enemy_animation_key(skeleton_name, "attack"),
-      duration = 350
-    )
-    damage <- enemy_damage[[skeleton_name]]
-    life_points <<- max(life_points - damage, 0)
-    update_life_points()
-    set_combat_status(sprintf(
-      "%s strikes you for %d damage.",
-      format_enemy_label(skeleton_name),
-      damage
-    ))
-    if (life_points <= 0 && !game_over_shown) {
-      game_over_shown <<- TRUE
-      shinyalert::shinyalert(
-        title = "Game Over",
-        text = "You have been defeated.",
-        type = "error"
-      )
-    }
-  }, ignoreNULL = TRUE)
 
   add_enemy_handlers <- function(skeleton_name) {
     force(skeleton_name)
@@ -669,17 +620,7 @@ server <- function(input, output, session) {
           }
         }
       },
-      input = input,
-      client_action = list(
-        set_text = list(
-          id = "combat_status",
-          text = sprintf("%s attacks!", format_enemy_label(skeleton_name))
-        ),
-        sprite = skeleton_name,
-        play_animation = enemy_animation_key(skeleton_name, "attack"),
-        duration = 350,
-        cooldown = enemy_attack_cooldown * 1000
-      )
+      input = input
     )
 
     game$add_overlap_end(
@@ -698,64 +639,6 @@ server <- function(input, output, session) {
   }
 
   lapply(enemy_names, add_enemy_handlers)
-}
-
-
-dungeonheroes_space_client_actions <- function(hero_attack_cooldown, enemy_names) {
-  enemy_hit_feedback <- lapply(enemy_names, function(enemy_name) {
-    list(
-      set_text = list(
-        id = "combat_status",
-        text = sprintf("You strike %s.", gsub("_", " ", enemy_name))
-      ),
-      when_overlap = c("hero", enemy_name),
-      when_exists = enemy_name
-    )
-  })
-
-  c(
-    list(
-      list(
-        destroy_sprite = "sword",
-        set_text = list(id = "inventory_weapon", text = "weapon: sword"),
-        sprite = "hero",
-        play_animation = "hero_sword",
-        when_overlap = c("hero", "sword"),
-        when_exists = "sword",
-        stop_after_match = TRUE
-      ),
-      list(
-        play_sound = "wizard_laugh",
-        show_alert = list(
-          title = "Dear, oh dear. What are you doing here in these dark forests, lad?",
-          text = "",
-          type = "info"
-        ),
-        when_overlap = c("hero", "wizard"),
-        cooldown = 1000,
-        stop_after_match = TRUE
-      )
-    ),
-    enemy_hit_feedback,
-    list(
-      list(
-        play_sound = "hero_attack",
-        sprite = "hero",
-        play_animation = "hero_attack",
-        duration = 500,
-        cooldown = hero_attack_cooldown * 1000,
-        when_exists = list(name = "sword", exists = TRUE)
-      ),
-      list(
-        play_sound = "hero_attack",
-        sprite = "hero",
-        play_animation = "hero_sword_attack",
-        duration = 500,
-        cooldown = hero_attack_cooldown * 1000,
-        when_exists = list(name = "sword", exists = FALSE)
-      )
-    )
-  )
 }
 
 

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -238,6 +238,13 @@ function runClientAction(key, action) {
     GameBridge.keyControlLastRun[cooldownKey] = now;
   }
 
+  if (action.raw_js) {
+    const snippets = Array.isArray(action.raw_js) ? action.raw_js : [action.raw_js];
+    for (const snippet of snippets) {
+      eval(snippet);
+    }
+  }
+
   if (action.play_sound) {
     playSound(action.play_sound, action.volume ?? null, action.loop ?? null);
   }

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -239,3 +239,28 @@ test_that("PhaserGame client actions do not require server callbacks", {
   expect_true(any(grepl('addOverlapEnd("hero", "wizard"', msgs, fixed = TRUE)))
   expect_true(any(grepl('"hide_text":"talk_bubble_text"', msgs, fixed = TRUE)))
 })
+
+
+test_that("overlap callbacks with direct object actions are recorded as client actions", {
+  session <- make_mock_session()
+  game <- PhaserGame$new()
+  game$set_shiny_session(session)
+
+  input <- list()
+  prompt <- game$add_text("...", "prompt", 0, 0, visible = FALSE)
+
+  game$add_overlap(
+    object_one = "hero",
+    object_two = "wizard",
+    callback_fun = function(evt) {
+      prompt$show()
+    },
+    input = input
+  )
+
+  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
+  overlap_msg <- msgs[grepl('addOverlap("hero", "wizard"', msgs, fixed = TRUE)]
+  expect_length(overlap_msg, 1)
+  expect_true(grepl('"raw_js"', overlap_msg, fixed = TRUE))
+  expect_true(grepl('showText(\'prompt\');', overlap_msg, fixed = TRUE))
+})


### PR DESCRIPTION
### Motivation
- Preserve the existing R `callback_fun` API while avoiding a Shiny round-trip for callbacks that only perform immediate browser-side object actions. 
- Make client-side actions the default when a callback can be statically recorded so gameplay feedback (e.g. showing text, playing an animation) is immediate and seamless. 
- Restore the per-overlap callback architecture in the `dungeonheroes` example to avoid overlapping helper logic and keep behavior consistent with the older branch. 

### Description
- Add a recording layer to `send_js` and a helper `record_client_callback()` in `R/utils.R` to capture JS emitted by simple R callback bodies and return a `raw_js` client-action payload. 
- Update `PhaserGame$add_overlap()` and `PhaserGame$add_overlap_end()` in `R/PhaserGame.R` to attempt recording the supplied `callback_fun` into `client_action` when `client_action` is `NULL`, and only register a server-side `observeEvent()` when recording fails. 
- Extend the browser client to execute recorded snippets by adding `raw_js` support in `inst/www/phaser-sprite.js` so `runClientAction()` will `eval()` captured JS before other client actions. 
- Rework `inst/examples/dungeonheroes.R` back to per-event `callback_fun` usage (remove the large client-action bundle) so overlapping logic runs via the R callbacks or is recorded as client actions where possible. 
- Add a test in `tests/testthat/test-core-methods.R` that verifies an overlap callback that simply calls `prompt$show()` is serialized as a `raw_js` client action. 

### Testing
- Ran `node --check inst/www/phaser-sprite.js` and `node --check inst/www/phaser-game.js`, both checks succeeded. 
- Ran `git diff --check` and fixed any whitespace/format issues, which succeeded. 
- Attempted to parse R sources with `Rscript` (`Rscript -e 'parse("R/PhaserGame.R"); parse("R/utils.R"); parse("inst/examples/dungeonheroes.R")'`) but `Rscript` was not available in the container, so R parsing/tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a468e10f51c832f9fb24ea94e0d391e)