### PR TITLE
Fix PhaserGame text session forwarding

### DIFF
--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -67,7 +67,10 @@ PhaserGame <- R6::R6Class(
     #' @param style Named list. Styling options passed to Phaser text rendering.
     #' @param visible Logical. Whether text is initially visible.
     add_text = function(text, id, x, y, style = list(font_size = '22px'), visible = TRUE) {
-      return(Text$new(text, id, x, y, style, visible))
+      return(Text$new(
+        text, id, x, y, style, visible,
+        session = private$session %||% shiny::getDefaultReactiveDomain()
+      ))
     },
 
     #' @description Add a rectangle object to the Phaser scene.


### PR DESCRIPTION
### Motivation
- Tests were failing with `attempt to apply non-function` because `Text` objects created via `PhaserGame$add_text()` did not receive the configured game `session`, causing `private$session$sendCustomMessage` to be called on a missing/incorrect session.

### Description
- Update `PhaserGame$add_text()` to forward the game session into `Text$new()` by passing `session = private$session %||% shiny::getDefaultReactiveDomain()` (in `R/PhaserGame.R`).
- This ensures text-related JS messages use the configured/mock Shiny session instead of falling back to the default reactive domain.

### Testing
- Ran `git diff --check` which succeeded.
- Attempted to run unit tests with `Rscript -e 'devtools::test(filter="core-methods")'`, but it could not be executed because `Rscript` is not available in the environment, so test run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46ae990068832fa364d569644112a8)