### PR TITLE
Update NEWS to document client_action parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinyphaser (development version)
 
+* Added a `client_action` parameter to `PhaserGame$add_overlap()`, `PhaserGame$add_overlap_end()`, and `PhaserGame$add_control()` so browser-side Phaser feedback can run immediately before Shiny callbacks are processed.
+
 * Added sound support with `PhaserGame$add_sound()` and a new `Sound` API for loading, playing, pausing, resuming, stopping, and configuring audio.
 
 * Added `set_scroll_factor()` helpers for scene objects so HUD-style elements can stay fixed while the camera follows another target.


### PR DESCRIPTION
### Motivation
- Document the addition of a `client_action` parameter to several `PhaserGame` methods so the development NEWS reflects the new ability to run browser-side Phaser feedback immediately before Shiny callbacks.

### Description
- Add a single NEWS entry in `NEWS.md` noting the new `client_action` parameter for `PhaserGame$add_overlap()`, `PhaserGame$add_overlap_end()`, and `PhaserGame$add_control()`.

### Testing
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46b15a6e6c832f90371d62b4f47001)