### PR TITLE
Resolve client_action merge conflicts and add client-side action handling

### DIFF
--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -231,27 +231,36 @@ PhaserGame <- R6::R6Class(
     add_overlap = function(object_one,
                            object_two = NULL,
                            group = NULL,
-                           callback_fun,
-                           input) {
+                           callback_fun = NULL,
+                           input,
+                           client_action = NULL) {
       Sys.sleep(0.1)
+      client_action <- validate_client_action(client_action)
       input_id <- paste(
         c("overlap", object_one,
           object_two %||% group),
         collapse = "_"
       )
 
-      event_endpoint <- register_phaser_event_endpoint(
-        private$session, input_id, callback_fun
-      )
+      event_endpoint <- input_id
+      if (!is.null(callback_fun)) {
+        event_endpoint <- register_phaser_event_endpoint(
+          private$session, input_id, callback_fun
+        )
+      }
 
       js <- if (!is.null(object_two)) {
-        sprintf("addOverlap('%s','%s',%s)",
-                object_one, object_two,
-                jsonlite::toJSON(event_endpoint, auto_unbox = TRUE))
+        sprintf("addOverlap(%s, %s, %s, %s)",
+                jsonlite::toJSON(object_one, auto_unbox = TRUE),
+                jsonlite::toJSON(object_two, auto_unbox = TRUE),
+                jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
+                jsonlite::toJSON(client_action %||% list(), auto_unbox = TRUE, null = "null"))
       } else {
-        sprintf("addGroupOverlap('%s','%s',%s)",
-                object_one, group,
-                jsonlite::toJSON(event_endpoint, auto_unbox = TRUE))
+        sprintf("addGroupOverlap(%s, %s, %s, %s)",
+                jsonlite::toJSON(object_one, auto_unbox = TRUE),
+                jsonlite::toJSON(group, auto_unbox = TRUE),
+                jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
+                jsonlite::toJSON(client_action %||% list(), auto_unbox = TRUE, null = "null"))
       }
       send_js(private, js)
     },
@@ -286,20 +295,27 @@ PhaserGame <- R6::R6Class(
    add_overlap_end = function(object_one,
                               object_two = NULL,
                               group = NULL,
-                              callback_fun,
+                              callback_fun = NULL,
                               input,
-                              session = shiny::getDefaultReactiveDomain()) {
+                              session = shiny::getDefaultReactiveDomain(),
+                              client_action = NULL) {
+     client_action <- validate_client_action(client_action)
      input_id <- paste(
        c("overlap_end", object_one,
          object_two %||% group),
        collapse = "_"
      )
-     event_endpoint <- register_phaser_event_endpoint(
-       session, input_id, callback_fun
-     )
-     js <- sprintf("addOverlapEnd('%s','%s',%s);",
-                   object_one, object_two,
-                   jsonlite::toJSON(event_endpoint, auto_unbox = TRUE))
+     event_endpoint <- input_id
+     if (!is.null(callback_fun)) {
+       event_endpoint <- register_phaser_event_endpoint(
+         session, input_id, callback_fun
+       )
+     }
+     js <- sprintf("addOverlapEnd(%s, %s, %s, %s);",
+                   jsonlite::toJSON(object_one, auto_unbox = TRUE),
+                   jsonlite::toJSON(object_two, auto_unbox = TRUE),
+                   jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
+                   jsonlite::toJSON(client_action %||% list(), auto_unbox = TRUE, null = "null"))
      session$sendCustomMessage("phaser", list(js = js))
    },
 
@@ -308,13 +324,20 @@ PhaserGame <- R6::R6Class(
    #'   event.code).
    #' @param action A function to be run after key is pressed.
    #' @param input Shiny input list.
-   add_control = function(key, action, input) {
+   add_control = function(key, action = NULL, input, client_action = NULL) {
      event <- paste0(key, "_action")
-     js <- sprintf("addKeyControl('%s');", key)
+     client_action <- validate_client_action(client_action)
+     js <- sprintf(
+       "addKeyControl(%s, %s);",
+       jsonlite::toJSON(key, auto_unbox = TRUE),
+       jsonlite::toJSON(client_action %||% list(), auto_unbox = TRUE, null = "null")
+     )
      send_js(private, js)
-     shiny::observeEvent(input[[event]], {
-       action()
-     })
+     if (!is.null(action)) {
+       shiny::observeEvent(input[[event]], {
+         action()
+       })
+     }
    }
   ),
   private = list(

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,3 +37,11 @@ register_phaser_event_endpoint <- function(session, event_id, callback_fun) {
     }
   )
 }
+
+
+validate_client_action <- function(client_action = NULL) {
+  if (!is.null(client_action) && !is.list(client_action)) {
+    stop("client_action must be a list or list of lists.", call. = FALSE)
+  }
+  client_action
+}

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -10,6 +10,7 @@ GameBridge.pendingScrollFactor = GameBridge.pendingScrollFactor || {};
 GameBridge.pendingWorldBounds = GameBridge.pendingWorldBounds || null;
 GameBridge.sounds = GameBridge.sounds || {};
 GameBridge.pendingSoundActions = GameBridge.pendingSoundActions || {};
+GameBridge.clientState = GameBridge.clientState || {};
 
 
 function sendPhaserEvent(target, payload) {
@@ -57,6 +58,7 @@ function playTypeAnim(sprite, type, suffix) {
 
 function initPhaserGame(containerId, config) {
   GameBridge.overlapEndWatchers = {};
+  GameBridge.clientState = {};
 
   window.game = new Phaser.Game({
     type: Phaser.AUTO,
@@ -358,12 +360,21 @@ function addGroupCollider(objectName, groupName, inputId) {
   );
 }
 
-function addOverlap(objectOneName, objectTwoName, inputId) {
+function retryWhenMissingObjects(fn, objectNames) {
+  const missingObject = objectNames.some((name) => !scene.children.getByName(name));
+  if (!missingObject) return false;
+  window.setTimeout(fn, 100);
+  return true;
+}
+
+function addOverlap(objectOneName, objectTwoName, inputId, clientActions = []) {
+  if (retryWhenMissingObjects(() => addOverlap(objectOneName, objectTwoName, inputId, clientActions), [objectOneName, objectTwoName])) return;
   const objectOne = scene.children.getByName(objectOneName);
   const objectTwo = scene.children.getByName(objectTwoName);
   scene.physics.add.overlap(
     objectOne, objectTwo,
     function(obj1, obj2) {
+      runClientActionList(inputId, clientActions);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );
@@ -390,10 +401,10 @@ function areOverlap(objectOneName, objectTwoName, inputId) {
   }
 };
 
-function addOverlapEnd(objectOneName, objectTwoName, inputId) {
+function addOverlapEnd(objectOneName, objectTwoName, inputId, clientActions = []) {
+  if (retryWhenMissingObjects(() => addOverlapEnd(objectOneName, objectTwoName, inputId, clientActions), [objectOneName, objectTwoName])) return;
   const obj1 = scene.children.getByName(objectOneName);
   const obj2 = scene.children.getByName(objectTwoName);
-  if (!obj1 || !obj2) return;
 
   const watcherKey = `${objectOneName}::${objectTwoName}::${inputId}`;
   if (GameBridge.overlapEndWatchers[watcherKey]) return;
@@ -407,6 +418,7 @@ function addOverlapEnd(objectOneName, objectTwoName, inputId) {
     );
 
     if (wasOverlapping && !currentlyOverlapping) {
+      runClientActionList(inputId, clientActions);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
 
@@ -414,12 +426,17 @@ function addOverlapEnd(objectOneName, objectTwoName, inputId) {
   });
 }
 
-function addGroupOverlap(objectName, groupName, inputId) {
+function addGroupOverlap(objectName, groupName, inputId, clientActions = []) {
+  if (!scene.children.getByName(objectName) || !scene[groupName]) {
+    window.setTimeout(() => addGroupOverlap(objectName, groupName, inputId, clientActions), 100);
+    return;
+  }
   const objectOne = scene.children.getByName(objectName);
   const objectTwo = scene[groupName];
   scene.physics.add.overlap(
     objectOne, objectTwo,
     function(obj1, obj2) {
+      runClientActionList(inputId, clientActions);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -1,9 +1,12 @@
 window.GameBridge = window.GameBridge || {};
 GameBridge.keyControlHandlers = GameBridge.keyControlHandlers || {};
+GameBridge.keyControlActions = GameBridge.keyControlActions || {};
+GameBridge.keyControlLastRun = GameBridge.keyControlLastRun || {};
 GameBridge.forcedAnimations = GameBridge.forcedAnimations || {};
 GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
 GameBridge.pendingScrollFactor = GameBridge.pendingScrollFactor || {};
 GameBridge.pendingSpriteActions = GameBridge.pendingSpriteActions || {};
+GameBridge.clientState = GameBridge.clientState || {};
 
 
 
@@ -189,7 +192,154 @@ function destroySprite(name) {
   sprite.destroy();
 }
 
-function addKeyControl(key) {
+function getClientObject(name) {
+  return scene && scene.children && scene.children.getByName(name);
+}
+
+function objectExists(name) {
+  const object = getClientObject(name);
+  return Boolean(object && object.active !== false);
+}
+
+function objectsOverlap(objectNames) {
+  if (!Array.isArray(objectNames) || objectNames.length !== 2) return false;
+  const objectOne = getClientObject(objectNames[0]);
+  const objectTwo = getClientObject(objectNames[1]);
+  if (!objectOne || !objectTwo || !objectOne.getBounds || !objectTwo.getBounds) return false;
+  return Phaser.Geom.Intersects.RectangleToRectangle(objectOne.getBounds(), objectTwo.getBounds());
+}
+
+function ensureClientState() {
+  window.GameBridge = window.GameBridge || {};
+  GameBridge.clientState = GameBridge.clientState || {};
+  return GameBridge.clientState;
+}
+
+function getClientState(key) {
+  return ensureClientState()[String(key || "")];
+}
+
+function setClientState(key, value) {
+  ensureClientState()[String(key || "")] = value;
+  return value;
+}
+
+function clampNumber(value, min, max) {
+  let nextValue = Number(value);
+  if (!Number.isFinite(nextValue)) nextValue = 0;
+  if (Number.isFinite(Number(min))) nextValue = Math.max(Number(min), nextValue);
+  if (Number.isFinite(Number(max))) nextValue = Math.min(Number(max), nextValue);
+  return nextValue;
+}
+
+function applyStateAction(stateAction) {
+  if (!stateAction || stateAction.key === undefined) return;
+  const key = String(stateAction.key || "");
+  const op = stateAction.op || "set";
+  const currentValue = Number(getClientState(key) ?? 0);
+  const amount = Number(stateAction.amount ?? stateAction.value ?? 0);
+  let nextValue;
+  if (op === "initialize" || op === "init") {
+    if (getClientState(key) !== undefined) return;
+    nextValue = amount;
+  } else if (op === "increment" || op === "add") {
+    nextValue = currentValue + amount;
+  } else if (op === "decrement" || op === "subtract") {
+    nextValue = currentValue - amount;
+  } else {
+    nextValue = amount;
+  }
+  setClientState(key, clampNumber(nextValue, stateAction.min, stateAction.max));
+}
+
+function interpolateClientStateText(text) {
+  return String(text || "").replace(/\{state\.([^}]+)\}/g, (_match, key) => {
+    const value = getClientState(key);
+    return value === undefined ? "" : String(value);
+  });
+}
+
+function stateConditionPasses(condition) {
+  if (!condition || condition.key === undefined) return true;
+  const actual = Number(getClientState(condition.key) ?? 0);
+  const value = Number(condition.value ?? 0);
+  const op = condition.op || "eq";
+  if (op === "lte") return actual <= value;
+  if (op === "lt") return actual < value;
+  if (op === "gte") return actual >= value;
+  if (op === "gt") return actual > value;
+  if (op === "neq") return actual !== value;
+  return actual === value;
+}
+
+function actionConditionPasses(action) {
+  if (action.when_overlap && !objectsOverlap(action.when_overlap)) return false;
+  if (action.when_state && !stateConditionPasses(action.when_state)) return false;
+  if (action.when_exists) {
+    const existsConditions = Array.isArray(action.when_exists) ? action.when_exists : [action.when_exists];
+    const allExist = existsConditions.every((condition) => {
+      if (typeof condition === "string") return objectExists(condition);
+      if (condition && typeof condition === "object") {
+        return objectExists(condition.name) === Boolean(condition.exists);
+      }
+      return false;
+    });
+    if (!allExist) return false;
+  }
+  return true;
+}
+
+function normalizeClientActions(clientActions) {
+  if (!clientActions || (Array.isArray(clientActions) && clientActions.length === 0)) return [];
+  return Array.isArray(clientActions) ? clientActions : [clientActions];
+}
+
+function showClientAlert(alertOptions) {
+  const options = typeof alertOptions === "string" ? { title: alertOptions } : alertOptions || {};
+  if (typeof swal === "function") { swal(options); return; }
+  if (typeof sweetAlert === "function") { sweetAlert(options); return; }
+  window.alert(options.title || options.text || "");
+}
+
+function runClientAction(key, action) {
+  if (!actionConditionPasses(action)) return false;
+  const cooldown = Number(action.cooldown || 0);
+  if (cooldown > 0) {
+    const cooldownKey = key + "::" + JSON.stringify(action);
+    const now = performance.now();
+    const lastRun = GameBridge.keyControlLastRun[cooldownKey];
+    if (lastRun !== undefined && (now - lastRun) < cooldown) return false;
+    GameBridge.keyControlLastRun[cooldownKey] = now;
+  }
+  if (action.set_state) (Array.isArray(action.set_state) ? action.set_state : [action.set_state]).forEach(applyStateAction);
+  if (action.raw_js) (Array.isArray(action.raw_js) ? action.raw_js : [action.raw_js]).forEach((snippet) => eval(snippet));
+  if (action.play_sound) playSound(action.play_sound, action.volume ?? null, action.loop ?? null);
+  if (action.play_animation) {
+    const spriteName = action.sprite || action.name;
+    if (Number.isFinite(action.duration)) playAnimationForDuration(spriteName, action.play_animation, action.duration);
+    else playAnimation(spriteName, action.play_animation);
+  }
+  if (action.destroy_sprite) destroySprite(action.destroy_sprite);
+  if (action.set_text && action.set_text.id !== undefined) setText(interpolateClientStateText(action.set_text.text || ""), action.set_text.id);
+  if (action.show_text) showText(action.show_text);
+  if (action.hide_text) hideText(action.hide_text);
+  if (action.show_alert) showClientAlert(action.show_alert);
+  return true;
+}
+
+function runClientActionList(key, actions) {
+  for (const action of normalizeClientActions(actions)) {
+    const didRun = runClientAction(key, action);
+    if (didRun && action.stop_after_match) break;
+  }
+}
+
+function runClientActions(key) {
+  runClientActionList(key, GameBridge.keyControlActions[key]);
+}
+
+function addKeyControl(key, clientActions = []) {
+  GameBridge.keyControlActions[key] = clientActions;
   if (GameBridge.keyControlHandlers[key]) {
     return;
   }
@@ -197,9 +347,10 @@ function addKeyControl(key) {
   const handler = function(e) {
     const inputId = key + "_action";
     if (key == e.code) {
+      runClientActions(key);
       Shiny.setInputValue(
         inputId,
-        e.code,
+        { code: e.code, evt_nonce: Date.now() + Math.random() },
         { priority: "event" }
       );
     }


### PR DESCRIPTION
### Motivation
- Introduce a `client_action` parameter so caller code can specify client-side actions to run on overlaps and key controls while preserving server-side endpoint dispatch. 
- Reconcile recent changes to optimized Phaser event endpoints with the new `client_action` flow so both client and server behaviors are supported.
- Provide deterministic client-side behavior when objects are not yet present by retrying registration until targets exist.

### Description
- Updated `PhaserGame` API to accept `client_action` in `add_overlap`, `add_overlap_end`, and `add_control`, and serialize that argument into the client JS calls using `jsonlite::toJSON`. 
- Added `validate_client_action` in `R/utils.R` to fail early if `client_action` is not a list. 
- Enhanced `inst/www/phaser-game.js` to initialize `GameBridge.clientState`, add `retryWhenMissingObjects`, and pass `clientActions` into `addOverlap`, `addOverlapEnd`, and `addGroupOverlap` so client actions run before endpoint dispatch. 
- Added comprehensive client-side helpers to `inst/www/phaser-sprite.js` including client state management, action conditions, cooldown handling, `runClientAction`, `runClientActionList`, and changed `addKeyControl` to accept and run `clientActions` while still sending the Shiny input event.

### Testing
- Ran `node --check inst/www/phaser-game.js` which completed successfully. 
- Ran `node --check inst/www/phaser-sprite.js` which completed successfully. 
- Ran `git diff --check` which returned no whitespace/error issues. 
- Searched for unresolved conflict markers with `rg -n "<<<<<<<|=======|>>>>>>>" . || true` and found none. 
- Attempted to parse R files with `Rscript -e 'parse("R/PhaserGame.R"); parse("R/utils.R")'` but this could not be run in the environment because `Rscript` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46b477a318832fbb9607a6c60bf813)