### PR TITLE
Use server callback for skeleton overlaps

### DIFF
--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -564,26 +564,54 @@ server <- function(input, output, session) {
       object_one = "hero",
       object_two = skeleton_name,
       input = input,
-      client_action = c(
-        list(
-          list(
-            set_state = list(
-              list(key = "hero_life", op = "init", value = max_life_points, min = 0, max = max_life_points),
-              list(key = "hero_life", op = "decrement", amount = enemy_damage[[skeleton_name]], min = 0, max = max_life_points)
-            ),
-            set_text = list(
-              id = "combat_status",
-              text = sprintf("%s hits you for %d. Life: {state.hero_life}/%d", format_enemy_label(skeleton_name), enemy_damage[[skeleton_name]], max_life_points)
-            ),
-            sprite = skeleton_name,
-            play_animation = enemy_animation_key(skeleton_name, "attack"),
-            duration = 350,
-            cooldown = enemy_attack_cooldown * 1000
+      callback_fun = function(evt) {
+        now <- as.numeric(Sys.time())
+        if (
+          !isTRUE(enemy_is_alive[[skeleton_name]]) ||
+            life_points <= 0 ||
+            (now - enemy_last_attack_time[[skeleton_name]]) < enemy_attack_cooldown
+        ) {
+          return(invisible(NULL))
+        }
+
+        enemy_in_range <<- skeleton_name
+        enemy_last_attack_time[[skeleton_name]] <<- now
+        life_points <<- max(0, life_points - enemy_damage[[skeleton_name]])
+
+        set_combat_status(sprintf(
+          "%s hits you for %d. Life: %d/%d",
+          format_enemy_label(skeleton_name),
+          enemy_damage[[skeleton_name]],
+          life_points,
+          max_life_points
+        ))
+        update_life_points()
+
+        enemies[[skeleton_name]]$play_animation(
+          enemy_animation_key(skeleton_name, "attack"),
+          duration = 350
+        )
+
+        if (life_points <= 0 && !isTRUE(game_over_shown)) {
+          game_over_shown <<- TRUE
+          session$sendCustomMessage(
+            "phaser",
+            list(js = paste0(
+              "if (window.GameBridge && GameBridge.playerControls) delete GameBridge.playerControls.hero;",
+              "const hero = scene.children.getByName('hero');",
+              "if (hero && hero.body && typeof hero.body.stop === 'function') hero.body.stop();"
+            ))
           )
-        ),
-        dungeonheroes_life_bar_client_actions(max_life_points, health_bar_segment_count),
-        list(dungeonheroes_game_over_client_action(skeleton_name))
-      )
+          set_combat_status(sprintf("%s defeated you. Game over.", format_enemy_label(skeleton_name)))
+          shinyalert::shinyalert(
+            title = "Game over",
+            text = "Your life points reached 0.",
+            type = "error",
+            closeOnClickOutside = FALSE,
+            showCancelButton = FALSE
+          )
+        }
+      }
     )
 
     game$add_overlap_end(
@@ -602,41 +630,6 @@ server <- function(input, output, session) {
   }
 
   lapply(enemy_names, add_enemy_handlers)
-}
-
-
-dungeonheroes_life_bar_client_actions <- function(max_life_points, health_bar_segment_count) {
-  lapply(seq_len(health_bar_segment_count), function(segment_index) {
-    threshold <- (segment_index - 1) * max_life_points / health_bar_segment_count
-    list(
-      hide_when_state = list(
-        id = sprintf("life_bar_green_%02d", segment_index),
-        key = "hero_life",
-        op = "lte",
-        value = threshold
-      )
-    )
-  })
-}
-
-dungeonheroes_game_over_client_action <- function(enemy_name) {
-  list(
-    when_state = list(key = "hero_life", op = "lte", value = 0),
-    set_text = list(
-      id = "combat_status",
-      text = sprintf("%s defeated you. Game over.", gsub("_", " ", enemy_name))
-    ),
-    raw_js = paste0(
-      "const state = (window.GameBridge && GameBridge.clientState) || {};",
-      "if (!state.dungeonheroes_game_over) {",
-      "state.dungeonheroes_game_over = true;",
-      "if (window.GameBridge && GameBridge.playerControls) delete GameBridge.playerControls.hero;",
-      "const hero = scene.children.getByName('hero');",
-      "if (hero && hero.body && typeof hero.body.stop === 'function') hero.body.stop();",
-      "if (typeof swal === 'function') swal({ title: 'Game over', text: 'Your life points reached 0.', type: 'error', closeOnClickOutside: false, showCancelButton: false });",
-      "}"
-    )
-  )
 }
 
 
@@ -735,4 +728,3 @@ dungeonheroes_space_client_actions <- function(hero_attack_cooldown, enemy_specs
 
 
 shiny::shinyApp(ui, server)
-


### PR DESCRIPTION
### Motivation
- Move overlap handling for skeleton enemies from client-driven `client_action` lists to a server-side R callback so game state (life, cooldowns, enemy alive flags) is authoritative and safer to update from R.

### Description
- Replaced the `client_action` payload in `add_overlap` for skeleton enemies with a `callback_fun` in `inst/examples/dungeonheroes.R` that performs cooldown checks, decrements `life_points`, updates combat text via `set_combat_status`, and refreshes the life bar with `update_life_points()`.
- The server callback triggers the enemy attack animation with `enemies[[skeleton_name]]$play_animation(..., duration = 350)` and sets `enemy_in_range` / `enemy_last_attack_time` to enforce attack cooldowns.
- Added server-side game-over handling that disables player controls via a custom message to the client, sets the combat status text, and shows a `shinyalert` when life reaches zero.
- Removed now-unused helper client-action functions `dungeonheroes_life_bar_client_actions` and `dungeonheroes_game_over_client_action` from the example since their behavior is implemented on the server.

### Testing
- Ran `git diff --check` which reported no whitespace/patch errors and succeeded. 
- Attempted to run `Rscript -e 'parse("inst/examples/dungeonheroes.R")'` to validate R syntax but the environment lacks `Rscript`, so that parse step could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48cdec603c832fb54eeab6ff87e100)