### PR TITLE
Add R-style `action` blocks for immediate browser-side Phaser reactions and compile to safe browser commands

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyphaser
 Title: An Interface to the 'Phaser.js' Game Framework
-Version: 0.1.0.9010
+Version: 0.1.0.9011
 Authors@R: 
     person(
       given = "Maciej", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ BugReports: https://github.com/maciekbanas/shinyphaser/issues
 Imports:
   htmltools,
   jsonlite,
-  promises,
   R6,
   rlang,
   shiny

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Performance improvements
 * Optimized Phaser collision and overlap callbacks by routing high-frequency events through Shiny data endpoints backed by `promises`, with a client-side fallback to `Shiny.setInputValue()`.
-* Added a `client_action` parameter to `PhaserGame$add_overlap()`, `PhaserGame$add_overlap_end()`, and `PhaserGame$add_control()` so browser-side Phaser feedback can run immediately before Shiny callbacks are processed.
+* Added R-style `action` blocks for immediate browser-side overlap and collision reactions.
 * Queued sprite physics actions until sprites finish loading so setup calls such as `set_gravity()` are not lost during asynchronous asset initialization.
 
 ## New interface features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,14 @@
 # shinyphaser (development version)
 
 ## Performance improvements
-* Optimized Phaser collision and overlap callbacks by routing high-frequency events through Shiny data endpoints backed by `promises`, with a client-side fallback to `Shiny.setInputValue()`.
+* Reduced high-frequency overlap traffic by keeping immediate actions in the browser and making server notification opt-in.
 * Added R-style `action` blocks for immediate browser-side overlap and collision reactions.
+* Extended action blocks with browser state, cooldowns, restricted conditionals,
+  overlap/existence predicates, alerts, semantic events, and immediate key controls.
+* Overlaps are edge-triggered by default and notify Shiny only when
+  `notify_server = TRUE`; sustained handlers can use `mode = "stay"` and
+  `interval` throttling.
+* Moved sprite movement delays from blocking R sleeps to browser timers.
 * Queued sprite physics actions until sprites finish loading so setup calls such as `set_gravity()` are not lost during asynchronous asset initialization.
 
 ## New interface features

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -161,13 +161,19 @@ PhaserGame <- R6::R6Class(
                           x, y,
                           frame_width, frame_height,
                           frame_count = 1, frame_rate = 1) {
-      return(Sprite$new(name, url, x, y, frame_width, frame_height, frame_count, frame_rate))
+      return(Sprite$new(
+        name, url, x, y, frame_width, frame_height, frame_count, frame_rate,
+        session = private$session %||% shiny::getDefaultReactiveDomain()
+      ))
     },
 
     #' @description Adds a dynamic group from a spritesheet.
     #' @param name Character. Unique name of the group.
     add_group = function(name) {
-      return(Group$new(name))
+      return(Group$new(
+        name,
+        session = private$session %||% shiny::getDefaultReactiveDomain()
+      ))
    },
 
     #' @description Adds a static sprite to the scene (non-animated).
@@ -176,7 +182,10 @@ PhaserGame <- R6::R6Class(
     #' @param x Numeric. X-coordinate in pixels.
     #' @param y Numeric. Y-coordinate in pixels.
     add_static_sprite = function(name, url, x, y) {
-      return(StaticSprite$new(name, url, x, y))
+      return(StaticSprite$new(
+        name, url, x, y,
+        session = private$session %||% shiny::getDefaultReactiveDomain()
+      ))
     },
 
     #' @description Adds a static group to the scene (non-animated).
@@ -185,7 +194,8 @@ PhaserGame <- R6::R6Class(
     add_static_group = function(name, url) {
       return(StaticGroup$new(
         name = name,
-        url = url
+        url = url,
+        session = private$session %||% shiny::getDefaultReactiveDomain()
       ))
     },
 
@@ -193,13 +203,20 @@ PhaserGame <- R6::R6Class(
     #' @param object_one Character. Name of the first object.
     #' @param object_two Character. Name of the second object.
     #' @param group Character. Name of the group to compare against.
-    #' @param callback_fun A function to be run when collision occurs.
+    #' @param action R code containing supported shinyphaser R6 method calls. It
+    #'   is compiled when registered and runs immediately in the browser when a
+    #'   collision occurs, without a Shiny round trip.
     #' @param input Shiny input list.
+    #' @param callback_fun Deprecated server-side collision callback. Prefer
+    #'   `action` when the work can be expressed with supported R6 methods.
     add_collider = function(object_one,
                             object_two = NULL,
                             group = NULL,
-                            callback_fun = NULL,
-                            input) {
+                            action = NULL,
+                            input,
+                            callback_fun = NULL) {
+      action_expr <- substitute(action)
+      browser_actions <- compile_phaser_action(action_expr, parent.frame())
       input_id <- paste(
         c("collide", object_one,
           object_two %||% group),
@@ -214,13 +231,15 @@ PhaserGame <- R6::R6Class(
       }
 
       js <- if (!is.null(object_two)) {
-        sprintf("addCollider('%s','%s',%s)",
+        sprintf("addCollider('%s','%s',%s,%s)",
                 object_one, object_two,
-                jsonlite::toJSON(event_target, auto_unbox = TRUE))
+                jsonlite::toJSON(event_target, auto_unbox = TRUE),
+                jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"))
       } else {
-        sprintf("addGroupCollider('%s','%s',%s)",
+        sprintf("addGroupCollider('%s','%s',%s,%s)",
                 object_one, group,
-                jsonlite::toJSON(event_target, auto_unbox = TRUE))
+                jsonlite::toJSON(event_target, auto_unbox = TRUE),
+                jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"))
       }
       send_js(private, js)
     },
@@ -229,18 +248,21 @@ PhaserGame <- R6::R6Class(
     #' @param object_one Character. Name of the first object.
     #' @param object_two Character. Name of the second object.
     #' @param group Character. Name of the group.
-    #' @param callback_fun A function to be run when overlap occurs.
+    #' @param action R code containing supported shinyphaser R6 method calls. It
+    #'   is compiled when registered and runs immediately in the browser when an
+    #'   overlap occurs, without a Shiny round trip.
     #' @param input Shiny input list.
-    #' @param client_action Optional list or list of lists describing immediate
-    #'   browser-side Phaser feedback to run when overlap occurs.
+    #' @param callback_fun Deprecated server-side overlap callback. Prefer
+    #'   `action` when the work can be expressed with supported R6 methods.
     add_overlap = function(object_one,
                            object_two = NULL,
                            group = NULL,
-                           callback_fun = NULL,
+                           action = NULL,
                            input,
-                           client_action = NULL) {
+                           callback_fun = NULL) {
       Sys.sleep(0.1)
-      client_action <- validate_client_action(client_action)
+      action_expr <- substitute(action)
+      browser_actions <- compile_phaser_action(action_expr, parent.frame())
 
       input_id <- paste(
         c("overlap", object_one,
@@ -260,13 +282,13 @@ PhaserGame <- R6::R6Class(
                 jsonlite::toJSON(object_one, auto_unbox = TRUE),
                 jsonlite::toJSON(object_two, auto_unbox = TRUE),
                 jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
-                jsonlite::toJSON(client_action %||% list(), auto_unbox = TRUE, null = "null"))
+                jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"))
       } else {
         sprintf("addGroupOverlap(%s, %s, %s, %s)",
                 jsonlite::toJSON(object_one, auto_unbox = TRUE),
                 jsonlite::toJSON(group, auto_unbox = TRUE),
                 jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
-                jsonlite::toJSON(client_action %||% list(), auto_unbox = TRUE, null = "null"))
+                jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"))
       }
       send_js(private, js)
     },
@@ -295,19 +317,21 @@ PhaserGame <- R6::R6Class(
    #' @param object_one Character. Name of the first object.
    #' @param object_two Character. Name of the second object.
    #' @param group Character. Name of the group to compare against.
-   #' @param callback_fun Function. Callback executed when overlap ends.
+   #' @param action R code containing supported shinyphaser R6 method calls. It
+   #'   is compiled when registered and runs immediately in the browser when the
+   #'   overlap ends, without a Shiny round trip.
    #' @param input Shiny input list.
    #' @param session Shiny session object.
-   #' @param client_action Optional list or list of lists describing immediate
-   #'   browser-side Phaser feedback to run when overlap ends.
+   #' @param callback_fun Deprecated server-side callback. Prefer `action`.
    add_overlap_end = function(object_one,
                               object_two = NULL,
                               group = NULL,
-                              callback_fun = NULL,
+                              action = NULL,
                               input,
                               session = shiny::getDefaultReactiveDomain(),
-                              client_action = NULL) {
-     client_action <- validate_client_action(client_action)
+                              callback_fun = NULL) {
+     action_expr <- substitute(action)
+     browser_actions <- compile_phaser_action(action_expr, parent.frame())
 
      input_id <- paste(
        c("overlap_end", object_one,
@@ -324,7 +348,7 @@ PhaserGame <- R6::R6Class(
                    jsonlite::toJSON(object_one, auto_unbox = TRUE),
                    jsonlite::toJSON(object_two, auto_unbox = TRUE),
                    jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
-                   jsonlite::toJSON(client_action %||% list(), auto_unbox = TRUE, null = "null"))
+                   jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"))
      session$sendCustomMessage("phaser", list(js = js))
    },
 
@@ -333,19 +357,13 @@ PhaserGame <- R6::R6Class(
    #'   event.code).
    #' @param action A function to be run after key is pressed.
    #' @param input Shiny input list.
-   #' @param client_action Optional list or list of lists describing immediate
-   #'   browser-side Phaser feedback to run on keydown before Shiny receives the
-   #'   event.
    add_control = function(key,
                           action = NULL,
-                          input,
-                          client_action = NULL) {
+                          input) {
      event <- paste0(key, "_action")
-     client_action <- validate_client_action(client_action)
      js <- sprintf(
-       "addKeyControl(%s, %s);",
-       jsonlite::toJSON(key, auto_unbox = TRUE),
-       jsonlite::toJSON(client_action %||% list(), auto_unbox = TRUE, null = "null")
+       "addKeyControl(%s);",
+       jsonlite::toJSON(key, auto_unbox = TRUE)
      )
      send_js(private, js)
      if (!is.null(action)) {

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -109,6 +109,21 @@ PhaserGame <- R6::R6Class(
       ))
     },
 
+    #' @description Create browser-resident state for use in action blocks.
+    #' @param key Character. Unique state key.
+    #' @param initial Initial JSON-serializable value.
+    add_state = function(key, initial = NULL) {
+      send_js(private, sprintf("setBrowserState(%s, %s);",
+        jsonlite::toJSON(key, auto_unbox = TRUE),
+        jsonlite::toJSON(initial, auto_unbox = TRUE, null = "null")))
+      BrowserState$new(key)
+    },
+
+    #' @description Create a browser-resident cooldown for action conditions.
+    #' @param key Character. Unique cooldown key.
+    #' @param duration Numeric. Cooldown duration in milliseconds.
+    add_cooldown = function(key, duration) BrowserCooldown$new(key, duration),
+
     #' @description Add a background (tilemap) layer from Tiled JSON + tileset image(s).
     #' @param map_key Character. Key for the tilemap JSON.
     #' @param map_url Character. URL of the Tiled JSON file (relative to www/assets/).
@@ -207,14 +222,13 @@ PhaserGame <- R6::R6Class(
     #'   is compiled when registered and runs immediately in the browser when a
     #'   collision occurs, without a Shiny round trip.
     #' @param input Shiny input list.
-    #' @param callback_fun Deprecated server-side collision callback. Prefer
-    #'   `action` when the work can be expressed with supported R6 methods.
+    #' @param notify_server Logical. Whether to also emit a Shiny input event.
     add_collider = function(object_one,
                             object_two = NULL,
                             group = NULL,
                             action = NULL,
-                            input,
-                            callback_fun = NULL) {
+                            input = NULL,
+                            notify_server = FALSE) {
       action_expr <- substitute(action)
       browser_actions <- compile_phaser_action(action_expr, parent.frame())
       input_id <- paste(
@@ -223,12 +237,7 @@ PhaserGame <- R6::R6Class(
         collapse = "_"
       )
 
-      event_target <- input_id
-      if (!is.null(callback_fun)) {
-        event_target <- register_phaser_event_endpoint(
-          private$session, input_id, callback_fun
-        )
-      }
+      event_target <- if (notify_server) input_id else NULL
 
       js <- if (!is.null(object_two)) {
         sprintf("addCollider('%s','%s',%s,%s)",
@@ -252,17 +261,21 @@ PhaserGame <- R6::R6Class(
     #'   is compiled when registered and runs immediately in the browser when an
     #'   overlap occurs, without a Shiny round trip.
     #' @param input Shiny input list.
-    #' @param callback_fun Deprecated server-side overlap callback. Prefer
-    #'   `action` when the work can be expressed with supported R6 methods.
+    #' @param mode Character. `"enter"` (default) runs once per contact;
+    #'   `"stay"` repeats while overlapping.
+    #' @param interval Numeric. Minimum milliseconds between `"stay"` actions.
+    #' @param notify_server Logical. Whether to also emit a Shiny input event.
     add_overlap = function(object_one,
                            object_two = NULL,
                            group = NULL,
                            action = NULL,
-                           input,
-                           callback_fun = NULL) {
-      Sys.sleep(0.1)
+                           input = NULL,
+                           mode = c("enter", "stay"),
+                           interval = 0,
+                           notify_server = FALSE) {
       action_expr <- substitute(action)
       browser_actions <- compile_phaser_action(action_expr, parent.frame())
+      mode <- match.arg(mode)
 
       input_id <- paste(
         c("overlap", object_one,
@@ -270,25 +283,22 @@ PhaserGame <- R6::R6Class(
         collapse = "_"
       )
 
-      event_endpoint <- input_id
-      if (!is.null(callback_fun)) {
-        event_endpoint <- register_phaser_event_endpoint(
-          private$session, input_id, callback_fun
-        )
-      }
+      event_endpoint <- if (notify_server) input_id else NULL
 
       js <- if (!is.null(object_two)) {
-        sprintf("addOverlap(%s, %s, %s, %s)",
+        sprintf("addOverlap(%s, %s, %s, %s, %s, %s)",
                 jsonlite::toJSON(object_one, auto_unbox = TRUE),
                 jsonlite::toJSON(object_two, auto_unbox = TRUE),
                 jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
-                jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"))
+                jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"),
+                jsonlite::toJSON(mode, auto_unbox = TRUE), interval)
       } else {
-        sprintf("addGroupOverlap(%s, %s, %s, %s)",
+        sprintf("addGroupOverlap(%s, %s, %s, %s, %s, %s)",
                 jsonlite::toJSON(object_one, auto_unbox = TRUE),
                 jsonlite::toJSON(group, auto_unbox = TRUE),
                 jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
-                jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"))
+                jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"),
+                jsonlite::toJSON(mode, auto_unbox = TRUE), interval)
       }
       send_js(private, js)
     },
@@ -322,14 +332,14 @@ PhaserGame <- R6::R6Class(
    #'   overlap ends, without a Shiny round trip.
    #' @param input Shiny input list.
    #' @param session Shiny session object.
-   #' @param callback_fun Deprecated server-side callback. Prefer `action`.
+   #' @param notify_server Logical. Whether to also emit a Shiny input event.
    add_overlap_end = function(object_one,
                               object_two = NULL,
                               group = NULL,
                               action = NULL,
-                              input,
+                              input = NULL,
                               session = shiny::getDefaultReactiveDomain(),
-                              callback_fun = NULL) {
+                              notify_server = FALSE) {
      action_expr <- substitute(action)
      browser_actions <- compile_phaser_action(action_expr, parent.frame())
 
@@ -338,12 +348,7 @@ PhaserGame <- R6::R6Class(
          object_two %||% group),
        collapse = "_"
      )
-     event_endpoint <- input_id
-     if (!is.null(callback_fun)) {
-       event_endpoint <- register_phaser_event_endpoint(
-         session, input_id, callback_fun
-       )
-     }
+     event_endpoint <- if (notify_server) input_id else NULL
      js <- sprintf("addOverlapEnd(%s, %s, %s, %s);",
                    jsonlite::toJSON(object_one, auto_unbox = TRUE),
                    jsonlite::toJSON(object_two, auto_unbox = TRUE),
@@ -355,22 +360,22 @@ PhaserGame <- R6::R6Class(
    #' @description Register a callback fired when a specific key is pressed.
    #' @param key A character, accepts Javascript key events (they need to align with
    #'   event.code).
-   #' @param action A function to be run after key is pressed.
+   #' @param action R code compiled and run immediately in the browser.
    #' @param input Shiny input list.
+   #' @param notify_server Logical. Whether to also emit a Shiny input event.
    add_control = function(key,
                           action = NULL,
-                          input) {
-     event <- paste0(key, "_action")
+                          input = NULL,
+                          notify_server = FALSE) {
+     action_expr <- substitute(action)
+     browser_actions <- compile_phaser_action(action_expr, parent.frame())
      js <- sprintf(
-       "addKeyControl(%s);",
-       jsonlite::toJSON(key, auto_unbox = TRUE)
+       "addKeyControl(%s, %s, %s);",
+       jsonlite::toJSON(key, auto_unbox = TRUE),
+       jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"),
+       tolower(notify_server)
      )
      send_js(private, js)
-     if (!is.null(action)) {
-       shiny::observeEvent(input[[event]], {
-         action()
-       })
-     }
    }
   ),
   private = list(

--- a/R/browser_state.R
+++ b/R/browser_state.R
@@ -1,0 +1,18 @@
+BrowserState <- R6::R6Class(
+  "BrowserState",
+  public = list(
+    initialize = function(key) private$key <- key
+  ),
+  private = list(key = NULL)
+)
+
+BrowserCooldown <- R6::R6Class(
+  "BrowserCooldown",
+  public = list(
+    initialize = function(key, duration) {
+      private$key <- key
+      private$duration <- duration
+    }
+  ),
+  private = list(key = NULL, duration = NULL)
+)

--- a/R/sprites.R
+++ b/R/sprites.R
@@ -168,10 +168,9 @@ Sprite <- R6::R6Class(
                              speed,
                              distance,
                              lag = distance/speed) {
-      Sys.sleep(lag)
       js <- sprintf(
-        "setSpriteInMotion('%s', %d, %d, %d, %d);",
-        private$name, dir_x, dir_y, speed, distance
+        "window.setTimeout(function() { setSpriteInMotion('%s', %d, %d, %d, %d); }, %f);",
+        private$name, dir_x, dir_y, speed, distance, lag * 1000
       )
       send_js(private, js)
     },
@@ -195,13 +194,12 @@ Sprite <- R6::R6Class(
                                               approach_speed_multiplier = 1,
                                               approach_distance_multiplier = 1,
                                               lag = distance/speed) {
-      Sys.sleep(lag)
       js <- sprintf(
-        "setSpriteInMotionRandomOrToward(%s, %s, %f, %f, %f, %f, %f, %f, %f);",
+        "window.setTimeout(function() { setSpriteInMotionRandomOrToward(%s, %s, %f, %f, %f, %f, %f, %f, %f); }, %f);",
         jsonlite::toJSON(private$name, auto_unbox = TRUE),
         jsonlite::toJSON(target_name, auto_unbox = TRUE),
         sight_range, dir_x, dir_y, speed, distance,
-        approach_speed_multiplier, approach_distance_multiplier
+        approach_speed_multiplier, approach_distance_multiplier, lag * 1000
       )
       send_js(private, js)
     },
@@ -213,17 +211,19 @@ Sprite <- R6::R6Class(
     #' @param distance Numeric. Distance in pixels to travel for each approach step.
     #' @param check_interval Numeric. Milliseconds between sight checks.
     #' @param alert_duration Numeric. Milliseconds to show the alert before approaching.
+    #' @param wander_interval Numeric. Milliseconds between random movements while the target is out of sight.
     start_approach_on_sight = function(target_name,
                                        sight_range,
                                        speed,
                                        distance,
                                        check_interval = 250,
-                                       alert_duration = 1200) {
+                                       alert_duration = 1200,
+                                       wander_interval = 1500) {
       js <- sprintf(
-        "startSpriteApproachOnSight(%s, %s, %f, %f, %f, %f, %f);",
+        "startSpriteApproachOnSight(%s, %s, %f, %f, %f, %f, %f, %f);",
         jsonlite::toJSON(private$name, auto_unbox = TRUE),
         jsonlite::toJSON(target_name, auto_unbox = TRUE),
-        sight_range, speed, distance, check_interval, alert_duration
+        sight_range, speed, distance, check_interval, alert_duration, wander_interval
       )
       send_js(private, js)
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -117,6 +117,18 @@ compile_phaser_action_call <- function(expr, env) {
     if (!is.infinite(duration)) action$duration <- duration
     return(action)
   }
+  if (inherits(target, "Sprite") && method == "set_in_motion") {
+    return(list(set_in_motion = list(
+      name = object_name,
+      dir_x = value("dir_x", 1),
+      dir_y = value("dir_y", 2),
+      speed = value("speed", 3),
+      distance = value("distance", 4)
+    )))
+  }
+  if (inherits(target, "StaticGroup") && method == "disable") {
+    return(list(disable_overlap_member = object_name))
+  }
   if (inherits(target, c("Sprite", "StaticSprite")) && method == "destroy") {
     return(list(destroy_sprite = object_name))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,16 +30,21 @@ compile_phaser_value <- function(expr, env) {
 }
 
 compile_phaser_condition <- function(expr, env) {
-  if (is.call(expr) && as.character(expr[[1]]) %in% c("&&", "||")) {
-    return(list(op = as.character(expr[[1]]),
+  operator <- if (is.call(expr) && is.symbol(expr[[1]])) {
+    as.character(expr[[1]])
+  } else {
+    NULL
+  }
+  if (!is.null(operator) && operator %in% c("&&", "||")) {
+    return(list(op = operator,
                 left = compile_phaser_condition(expr[[2]], env),
                 right = compile_phaser_condition(expr[[3]], env)))
   }
   if (is.call(expr) && identical(expr[[1]], as.name("!"))) {
     return(list(op = "!", value = compile_phaser_condition(expr[[2]], env)))
   }
-  if (is.call(expr) && as.character(expr[[1]]) %in% c("==", "!=", "<", "<=", ">", ">=")) {
-    return(list(op = as.character(expr[[1]]),
+  if (!is.null(operator) && operator %in% c("==", "!=", "<", "<=", ">", ">=")) {
+    return(list(op = operator,
                 left = compile_phaser_value(expr[[2]], env),
                 right = compile_phaser_value(expr[[3]], env)))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,7 +70,7 @@ compile_phaser_action_call <- function(expr, env) {
     return(list(`if` = list(
       condition = compile_phaser_condition(expr[[2]], env),
       then = compile_phaser_action(expr[[3]], env),
-      else = if (length(expr) >= 4) compile_phaser_action(expr[[4]], env) else list()
+      `else` = if (length(expr) >= 4) compile_phaser_action(expr[[4]], env) else list()
     )))
   }
   if (!is.call(expr) || !is.call(expr[[1]]) ||

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,47 +2,6 @@ send_js <- function(private, js) {
   private$session$sendCustomMessage("phaser", list(js = js))
 }
 
-register_phaser_event_endpoint <- function(session, event_id, callback_fun) {
-  if (is.null(session)) {
-    session <- shiny::getDefaultReactiveDomain()
-  }
-  if (is.null(session)) {
-    stop("A Shiny session is required to register Phaser event endpoints.", call. = FALSE)
-  }
-
-  if (!is.function(session$registerDataObj)) {
-    return(event_id)
-  }
-
-  session$registerDataObj(
-    name = event_id,
-    data = callback_fun,
-    filterFunc = function(callback, req) {
-      body <- rawToChar(req$rook.input$read())
-      evt <- if (nzchar(body)) {
-        jsonlite::fromJSON(body, simplifyVector = FALSE)
-      } else {
-        list()
-      }
-
-      promise <- promises::then(promises::promise_resolve(evt), callback)
-      promises::catch(promise, function(error) {
-        warning(
-          sprintf("Phaser event callback '%s' failed: %s", event_id, error$message),
-          call. = FALSE
-        )
-      })
-
-      shiny::httpResponse(
-        status = 202,
-        content_type = "application/json",
-        content = '{"status":"accepted"}'
-      )
-    }
-  )
-}
-
-
 # Translate a deliberately small, R-looking action block into the declarative
 # commands understood by the browser.  The expression is never evaluated: doing
 # so would send the R6 commands to Shiny, which is precisely the round trip this
@@ -59,7 +18,61 @@ compile_phaser_action <- function(expr, env) {
   lapply(expressions, compile_phaser_action_call, env = env)
 }
 
+compile_phaser_value <- function(expr, env) {
+  if (is.call(expr) && is.call(expr[[1]]) && identical(expr[[1]][[1]], as.name("$"))) {
+    target <- eval(expr[[1]][[2]], env)
+    method <- as.character(expr[[1]][[3]])
+    if (inherits(target, "BrowserState") && method == "value") {
+      return(list(state = target$.__enclos_env__$private$key))
+    }
+  }
+  eval(expr, env)
+}
+
+compile_phaser_condition <- function(expr, env) {
+  if (is.call(expr) && as.character(expr[[1]]) %in% c("&&", "||")) {
+    return(list(op = as.character(expr[[1]]),
+                left = compile_phaser_condition(expr[[2]], env),
+                right = compile_phaser_condition(expr[[3]], env)))
+  }
+  if (is.call(expr) && identical(expr[[1]], as.name("!"))) {
+    return(list(op = "!", value = compile_phaser_condition(expr[[2]], env)))
+  }
+  if (is.call(expr) && as.character(expr[[1]]) %in% c("==", "!=", "<", "<=", ">", ">=")) {
+    return(list(op = as.character(expr[[1]]),
+                left = compile_phaser_value(expr[[2]], env),
+                right = compile_phaser_value(expr[[3]], env)))
+  }
+  if (is.call(expr) && is.call(expr[[1]]) && identical(expr[[1]][[1]], as.name("$"))) {
+    target <- eval(expr[[1]][[2]], env)
+    method <- as.character(expr[[1]][[3]])
+    args <- as.list(expr)[-1]
+    private <- target$.__enclos_env__$private
+    name <- private$id %||% private$name
+    if (method == "overlaps") {
+      other <- eval(args[[1]], env)
+      other_name <- other$.__enclos_env__$private$id %||% other$.__enclos_env__$private$name
+      return(list(op = "overlaps", objects = c(name, other_name)))
+    }
+    if (method == "exists") return(list(op = "exists", object = name))
+    if (inherits(target, "BrowserState") && method %in% c("is_true", "is_false")) {
+      return(list(op = method, state = private$key))
+    }
+    if (inherits(target, "BrowserCooldown") && method == "ready") {
+      return(list(op = "cooldown_ready", key = private$key, duration = private$duration))
+    }
+  }
+  stop("Unsupported condition in action block.", call. = FALSE)
+}
+
 compile_phaser_action_call <- function(expr, env) {
+  if (is.call(expr) && identical(expr[[1]], as.name("if"))) {
+    return(list(`if` = list(
+      condition = compile_phaser_condition(expr[[2]], env),
+      then = compile_phaser_action(expr[[3]], env),
+      else = if (length(expr) >= 4) compile_phaser_action(expr[[4]], env) else list()
+    )))
+  }
   if (!is.call(expr) || !is.call(expr[[1]]) ||
       !identical(expr[[1]][[1]], as.name("$"))) {
     stop(
@@ -71,7 +84,14 @@ compile_phaser_action_call <- function(expr, env) {
   target_expr <- expr[[1]][[2]]
   method <- as.character(expr[[1]][[3]])
   target <- eval(target_expr, envir = env)
-  args <- lapply(as.list(expr)[-1], eval, envir = env)
+  arg_exprs <- as.list(expr)[-1]
+  if (inherits(target, "PhaserGame") && method == "after") {
+    return(list(after = list(
+      delay = compile_phaser_value(arg_exprs[[1]], env),
+      actions = compile_phaser_action(arg_exprs[[2]], env)
+    )))
+  }
+  args <- lapply(arg_exprs, compile_phaser_value, env = env)
   arg_names <- names(as.list(expr)[-1])
   if (is.null(arg_names)) arg_names <- rep("", length(args))
   names(args) <- arg_names
@@ -126,8 +146,31 @@ compile_phaser_action_call <- function(expr, env) {
       distance = value("distance", 4)
     )))
   }
+  if (inherits(target, "Sprite") && method %in% c("set_velocity_x", "set_velocity_y")) {
+    return(setNames(list(list(name = object_name, value = value("x", 1, 100))), method))
+  }
+  if (inherits(target, "Sprite") && method == "add_player_controls") {
+    return(list(player_controls = list(
+      name = object_name,
+      directions = value("directions", 1, c("left", "right", "down", "up")),
+      speed = value("speed", 2, 200)
+    )))
+  }
   if (inherits(target, "StaticGroup") && method == "disable") {
     return(list(disable_overlap_member = object_name))
+  }
+  if (inherits(target, "BrowserState") && method %in% c("set", "increment", "decrement", "add", "subtract")) {
+    return(list(state_action = list(key = private$key, op = method,
+                                    value = value("value", 1, 1))))
+  }
+  if (inherits(target, "BrowserCooldown") && method == "trigger") {
+    return(list(cooldown_trigger = private$key))
+  }
+  if (inherits(target, "PhaserGame") && method == "alert") {
+    return(list(show_alert = args))
+  }
+  if (inherits(target, "PhaserGame") && method == "emit") {
+    return(list(emit = list(name = value("name", 1), data = value("data", 2, list()))))
   }
   if (inherits(target, c("Sprite", "StaticSprite")) && method == "destroy") {
     return(list(destroy_sprite = object_name))

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,10 +43,87 @@ register_phaser_event_endpoint <- function(session, event_id, callback_fun) {
 }
 
 
-validate_client_action <- function(client_action = NULL) {
-  if (!is.null(client_action) && !is.list(client_action)) {
-    stop("client_action must be a list or list of lists.", call. = FALSE)
+# Translate a deliberately small, R-looking action block into the declarative
+# commands understood by the browser.  The expression is never evaluated: doing
+# so would send the R6 commands to Shiny, which is precisely the round trip this
+# interface avoids.
+compile_phaser_action <- function(expr, env) {
+  if (identical(expr, quote(NULL))) return(list())
+
+  expressions <- if (is.call(expr) && identical(expr[[1]], as.name("{"))) {
+    as.list(expr)[-1]
+  } else {
+    list(expr)
   }
 
-  client_action
+  lapply(expressions, compile_phaser_action_call, env = env)
+}
+
+compile_phaser_action_call <- function(expr, env) {
+  if (!is.call(expr) || !is.call(expr[[1]]) ||
+      !identical(expr[[1]][[1]], as.name("$"))) {
+    stop(
+      "action must contain calls to supported shinyphaser R6 object methods.",
+      call. = FALSE
+    )
+  }
+
+  target_expr <- expr[[1]][[2]]
+  method <- as.character(expr[[1]][[3]])
+  target <- eval(target_expr, envir = env)
+  args <- lapply(as.list(expr)[-1], eval, envir = env)
+  arg_names <- names(as.list(expr)[-1])
+  if (is.null(arg_names)) arg_names <- rep("", length(args))
+  names(args) <- arg_names
+
+  private <- target$.__enclos_env__$private
+  object_name <- private$id %||% private$name
+  value <- function(name, position, default = NULL) {
+    if (name %in% names(args)) return(args[[name]])
+    if (length(args) >= position) return(args[[position]])
+    default
+  }
+
+  if (inherits(target, "Text") && method == "show") return(list(show_text = object_name))
+  if (inherits(target, "Text") && method == "hide") return(list(hide_text = object_name))
+  if (inherits(target, "Text") && method == "set") {
+    return(list(set_text = list(id = object_name, text = value("text", 1))))
+  }
+  if (inherits(target, c("Image", "Rectangle")) && method == "show") {
+    return(list(show_text = object_name))
+  }
+  if (inherits(target, c("Image", "Rectangle")) && method == "hide") {
+    return(list(hide_text = object_name))
+  }
+  if (inherits(target, "Sound") && method == "play") {
+    action <- list(play_sound = object_name)
+    volume <- value("volume", 1)
+    loop <- value("loop", 2)
+    if (!is.null(volume)) action$volume <- volume
+    if (!is.null(loop)) action$loop <- loop
+    return(action)
+  }
+  if (inherits(target, "Sound") && method %in% c("pause", "resume", "stop")) {
+    action <- list(object_name)
+    names(action) <- paste0(method, "_sound")
+    return(action)
+  }
+  if (inherits(target, "Sprite") && method == "play_animation") {
+    action <- list(
+      play_animation = value("anim_name", 1),
+      sprite = object_name
+    )
+    duration <- value("duration", 2, Inf)
+    if (!is.infinite(duration)) action$duration <- duration
+    return(action)
+  }
+  if (inherits(target, c("Sprite", "StaticSprite")) && method == "destroy") {
+    return(list(destroy_sprite = object_name))
+  }
+
+  stop(
+    sprintf("%s$%s() is not supported in an immediate action.",
+            class(target)[[1]], method),
+    call. = FALSE
+  )
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -82,7 +82,7 @@ game$add_collider(
 ```
 
 An immediate action can use supported methods on `Text`, `Image`, `Rectangle`,
-`Sound`, `Sprite`, and `StaticSprite` objects. Arbitrary R code (for example,
+`Sound`, `Sprite`, `StaticSprite`, and `StaticGroup` objects. Arbitrary R code (for example,
 updating a reactive value or querying a database) cannot run in a browser; keep
 that work in the server-side `callback_fun`.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -58,6 +58,34 @@ shinyphaser::run_sample_app()
 
 For a full walkthrough (from static background to movement, animation, overlap, and collision), see [**Build your first shinyphaser game**](https://maciekbanas.github.io/shinyphaser/articles/first-game.html)
 
+### Immediate overlap and collision actions
+
+Use `action` to write browser-speed reactions with the same R6 methods used in
+server code. The expression is captured when the handler is registered and
+compiled to safe browser commands; it is not run in the R session when the
+collision happens.
+
+```r
+game$add_overlap(
+  "hero", "wizard", input = input,
+  action = {
+    prompt$show()
+    greeting$play(volume = 0.5)
+    hero$play_animation("wave", duration = 500)
+  }
+)
+
+game$add_collider(
+  "hero", "rock", input = input,
+  action = warning_sound$play()
+)
+```
+
+An immediate action can use supported methods on `Text`, `Image`, `Rectangle`,
+`Sound`, `Sprite`, and `StaticSprite` objects. Arbitrary R code (for example,
+updating a reactive value or querying a database) cannot run in a browser; keep
+that work in the server-side `callback_fun`.
+
 ```{r, echo=FALSE}
 knitr::include_graphics("man/hedgehog_example.gif")
 ```

--- a/README.Rmd
+++ b/README.Rmd
@@ -84,7 +84,29 @@ game$add_collider(
 An immediate action can use supported methods on `Text`, `Image`, `Rectangle`,
 `Sound`, `Sprite`, `StaticSprite`, and `StaticGroup` objects. Arbitrary R code (for example,
 updating a reactive value or querying a database) cannot run in a browser; keep
-that work in the server-side `callback_fun`.
+that work behind a semantic event emitted with `game$emit()` and observed by
+Shiny. Browser-only actions do not send overlap traffic to the server unless
+`notify_server = TRUE` is requested explicitly.
+
+Browser-resident state, cooldowns, conditions, alerts, and semantic events can
+also be expressed with R-looking calls:
+
+```r
+has_sword <- game$add_state("has_sword", FALSE)
+attack <- game$add_cooldown("attack", 750)
+
+game$add_control("Space", input = input, action = {
+  if (hero$overlaps(sword) && sword$exists()) {
+    sword$destroy()
+    has_sword$set(TRUE)
+    inventory$set("weapon: sword")
+  } else if (attack$ready()) {
+    attack$trigger()
+    attack_sound$play()
+    game$emit("hero_attack")
+  }
+})
+```
 
 ```{r, echo=FALSE}
 knitr::include_graphics("man/hedgehog_example.gif")

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -64,7 +64,7 @@ server <- function(input, output, session) {
 
   game$add_control(
     "Space",
-    action = function() {
+    action = {
       jump_sound$play()
       bear$set_velocity_y(-600)
       bear$play_animation(

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -137,7 +137,7 @@ server <- function(input, output, session) {
   game$add_overlap(
     object_one = "bear",
     object_two = "wooden_box",
-    callback_fun = function(evt) {
+    action = {
       wooden_box$set_in_motion(
         dir_x = 1,
         dir_y = 0,
@@ -151,10 +151,9 @@ server <- function(input, output, session) {
   game$add_overlap(
     object_one = "bear",
     group = "apples",
-    callback_fun = function(evt) {
-      points <<- points + 1
-      points_text$set(paste0("apples gathered: ", points))
-      apples$disable(evt)
+    action = {
+      points_text$set("apple gathered!")
+      apples$disable()
     },
     input = input
   )

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -451,13 +451,7 @@ server <- function(input, output, session) {
   game$add_control(
     "Space",
     action = NULL,
-    input,
-    client_action = dungeonheroes_space_client_actions(
-      hero_attack_cooldown,
-      enemy_specs,
-      hero_fist_damage,
-      hero_sword_damage
-    )
+    input
   )
 
   inventory_text <- game$add_text(
@@ -562,47 +556,26 @@ server <- function(input, output, session) {
     object_one = "hero",
     object_two = "wizard",
     input = input,
-    client_action = list(
-      show_text = "talk_bubble_text",
-      sprite = "wizard",
-      play_animation = "wizard_talk",
-      duration = 2000,
-      play_sound = "wizard_laugh",
-      cooldown = 5000
-    )
+    action = {
+      talk_bubble_text$show()
+      wizard$play_animation("talk", duration = 2000)
+      wizard_laugh_sound$play()
+    }
   )
   game$add_overlap_end(
     object_one = "hero",
     object_two = "wizard",
     input = input,
-    client_action = list(
-      hide_text = "talk_bubble_text",
-      sprite = "wizard",
-      play_animation = "wizard_idle"
-    )
+    action = {
+      talk_bubble_text$hide()
+      wizard$play_animation("idle")
+    }
   )
 
   game$add_overlap(
     object_one = "hero",
     object_two = "mushroom_spirit",
-    input = input,
-    client_action = list(
-      show_alert = list(
-        title = "Mushroom spirit saved!",
-        text = "The good spirit is safe. You win!",
-        type = "success",
-        closeOnClickOutside = FALSE,
-        showCancelButton = FALSE
-      ),
-      raw_js = paste0(
-        "const state = (window.GameBridge && GameBridge.clientState) || {};",
-        "state.dungeonheroes_game_over = true;",
-        "if (window.GameBridge && GameBridge.playerControls) delete GameBridge.playerControls.hero;",
-        "const hero = scene.children.getByName('hero');",
-        "if (hero && hero.body && typeof hero.body.stop === 'function') hero.body.stop();"
-      ),
-      disable_sprite = "mushroom_spirit"
-    )
+    input = input
   )
 
   add_enemy_handlers <- function(enemy_name) {
@@ -614,32 +587,8 @@ server <- function(input, output, session) {
       callback_fun = function(evt) {
         enemy_in_range <<- enemy_name
       },
-      input = input,
-      client_action = c(
-        list(
-          list(
-            set_state = list(
-              list(key = "hero_life", op = "init", value = max_life_points, min = 0, max = max_life_points),
-              list(key = "hero_life", op = "decrement", amount = enemy_damage[[enemy_name]], min = 0, max = max_life_points)
-            ),
-            set_text = list(
-              id = "combat_status",
-              text = sprintf("%s hits you for %d. Life: {state.hero_life}/%d", format_enemy_label(enemy_name), enemy_damage[[enemy_name]], max_life_points)
-            ),
-            raw_js = sprintf(
-              "const enemy = scene.children.getByName('%s'); if (enemy) { scene.tweens.killTweensOf(enemy); if (enemy.body && typeof enemy.body.stop === 'function') enemy.body.stop(); }",
-              enemy_name
-            ),
-            sprite = enemy_name,
-            play_animation = enemy_animation_key(enemy_name, "attack"),
-            duration = 1000,
-            cooldown = enemy_attack_cooldown * 1000
-          )
-        ),
-        dungeonheroes_life_bar_client_actions(max_life_points, health_bar_segment_count),
-        list(dungeonheroes_game_over_client_action(enemy_name))
-      )
-    )
+      input = input
+  )
 
     game$add_overlap_end(
       object_one = "hero",
@@ -657,168 +606,6 @@ server <- function(input, output, session) {
   }
 
   lapply(enemy_names, add_enemy_handlers)
-}
-
-
-dungeonheroes_life_bar_client_actions <- function(max_life_points, health_bar_segment_count) {
-  lapply(seq_len(health_bar_segment_count), function(segment_index) {
-    threshold <- (segment_index - 1) * max_life_points / health_bar_segment_count
-    list(
-      hide_when_state = list(
-        id = sprintf("life_bar_green_%02d", segment_index),
-        key = "hero_life",
-        op = "lte",
-        value = threshold
-      )
-    )
-  })
-}
-
-dungeonheroes_game_over_client_action <- function(enemy_name) {
-  list(
-    when_state = list(key = "hero_life", op = "lte", value = 0),
-    set_text = list(
-      id = "combat_status",
-      text = sprintf("%s defeated you. Game over.", gsub("_", " ", enemy_name))
-    ),
-    raw_js = paste0(
-      "const state = (window.GameBridge && GameBridge.clientState) || {};",
-      "if (!state.dungeonheroes_game_over) {",
-      "state.dungeonheroes_game_over = true;",
-      "if (window.GameBridge && GameBridge.playerControls) delete GameBridge.playerControls.hero;",
-      "const hero = scene.children.getByName('hero');",
-      "if (hero && hero.body && typeof hero.body.stop === 'function') hero.body.stop();",
-      "if (typeof swal === 'function') swal({ title: 'Game over', text: 'Your life points reached 0.', type: 'error', closeOnClickOutside: false, showCancelButton: false });",
-      "}"
-    )
-  )
-}
-
-
-dungeonheroes_space_client_actions <- function(hero_attack_cooldown, enemy_specs, hero_fist_damage, hero_sword_damage) {
-  enemy_names <- vapply(enemy_specs, `[[`, character(1), "name")
-  enemy_max_hit_points <- stats::setNames(
-    vapply(enemy_specs, `[[`, numeric(1), "hit_points"),
-    enemy_names
-  )
-
-  enemy_hit_feedback <- unlist(lapply(enemy_names, function(enemy_name) {
-    enemy_label <- gsub("_", " ", enemy_name)
-    enemy_state_key <- paste0("enemy_life_", enemy_name)
-    enemy_max_life <- enemy_max_hit_points[[enemy_name]]
-    enemy_destroy_js <- sprintf(
-      paste0(
-        "const state = (window.GameBridge && GameBridge.clientState) || {};",
-        "const enemy = scene.children.getByName(%s);",
-        "if (state[%s] <= 0 && enemy && !enemy.getData('destroying')) {",
-        "enemy.setData('destroying', true);",
-        "scene.tweens.killTweensOf(enemy);",
-        "if (enemy.body) { enemy.body.enable = false; if (typeof enemy.body.stop === 'function') enemy.body.stop(); }",
-        "if (scene.anims.exists(%s)) enemy.play(%s, true);",
-        "setTimeout(function() { disableSprite(%s); }, 750);",
-        "}"
-      ),
-      jsonlite::toJSON(enemy_name, auto_unbox = TRUE),
-      jsonlite::toJSON(enemy_state_key, auto_unbox = TRUE),
-      jsonlite::toJSON(paste0(enemy_name, "_destroy"), auto_unbox = TRUE),
-      jsonlite::toJSON(paste0(enemy_name, "_destroy"), auto_unbox = TRUE),
-      jsonlite::toJSON(enemy_name, auto_unbox = TRUE)
-    )
-
-    list(
-      list(
-        set_state = list(
-          list(key = enemy_state_key, op = "init", value = enemy_max_life, min = 0, max = enemy_max_life),
-          list(key = enemy_state_key, op = "decrement", amount = hero_fist_damage, min = 0, max = enemy_max_life)
-        ),
-        set_text = list(
-          id = "combat_status",
-          text = sprintf("You punch %s for %d. Enemy life: {state.%s}/%d", enemy_label, hero_fist_damage, enemy_state_key, enemy_max_life)
-        ),
-        when_overlap = c("hero", enemy_name),
-        when_exists = list(
-          enemy_name,
-          list(name = "sword", exists = TRUE)
-        ),
-        raw_js = enemy_destroy_js
-      ),
-      list(
-        set_state = list(
-          list(key = enemy_state_key, op = "init", value = enemy_max_life, min = 0, max = enemy_max_life),
-          list(key = enemy_state_key, op = "decrement", amount = hero_sword_damage, min = 0, max = enemy_max_life)
-        ),
-        set_text = list(
-          id = "combat_status",
-          text = sprintf("You slash %s for %d. Enemy life: {state.%s}/%d", enemy_label, hero_sword_damage, enemy_state_key, enemy_max_life)
-        ),
-        when_overlap = c("hero", enemy_name),
-        when_exists = list(
-          enemy_name,
-          list(name = "sword", exists = FALSE)
-        ),
-        raw_js = enemy_destroy_js
-      )
-    )
-  }), recursive = FALSE)
-
-  c(
-    list(
-      list(
-        destroy_sprite = "sword",
-        set_text = list(id = "inventory_weapon", text = "weapon: sword"),
-        sprite = "hero",
-        play_animation = "hero_sword",
-        when_overlap = c("hero", "sword"),
-        when_exists = "sword",
-        stop_after_match = TRUE
-      ),
-      list(
-        show_alert = list(
-          title = "Dear, oh dear. What are you doing here in these dark forests, lad?",
-          text = "",
-          type = "info"
-        ),
-        raw_js = paste0(
-          "setTimeout(function() { ",
-          "if (typeof swal !== 'function') return; ",
-          "if (!document.getElementById('mushroom-spirit-alert-style')) { ",
-          "var style = document.createElement('style'); ",
-          "style.id = 'mushroom-spirit-alert-style'; ",
-          "style.textContent = '@keyframes mushroomSpiritAlert { from { background-position: 0 0; } to { background-position: -448px 0; } } .mushroom-spirit-alert-animation { width: 32px; height: 32px; margin: 0 auto; background-image: url(\"assets/dungeonheroes/sprites/mushroom_spirit.png\"); background-repeat: no-repeat; animation: mushroomSpiritAlert 1s steps(14) infinite; image-rendering: pixelated; }'; ",
-          "document.head.appendChild(style); ",
-          "} ",
-          "swal({ ",
-          "title: 'There is a good spirit waiting to be saved!', ",
-          "text: '<div class=\"mushroom-spirit-alert-animation\"></div>', ",
-          "html: true ",
-          "}); ",
-          "}, 2200);"
-        ),
-        when_overlap = c("hero", "wizard"),
-        cooldown = 1000,
-        stop_after_match = TRUE
-      )
-    ),
-    enemy_hit_feedback,
-    list(
-      list(
-        play_sound = "hero_attack",
-        sprite = "hero",
-        play_animation = "hero_attack",
-        duration = 500,
-        cooldown = hero_attack_cooldown * 1000,
-        when_exists = list(name = "sword", exists = TRUE)
-      ),
-      list(
-        play_sound = "hero_attack",
-        sprite = "hero",
-        play_animation = "hero_sword_attack",
-        duration = 500,
-        cooldown = hero_attack_cooldown * 1000,
-        when_exists = list(name = "sword", exists = FALSE)
-      )
-    )
-  )
 }
 
 

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -425,7 +425,7 @@ server <- function(input, output, session) {
     )
   })
 
-  shiny::observeEvent(input$phaser_dungeon_space, {
+  shiny::observeEvent(input$Space_action, {
       if (life_points <= 0) return(invisible(NULL))
 
       if (sword_in_range && !has_sword) {
@@ -481,7 +481,12 @@ server <- function(input, output, session) {
 
   }, ignoreInit = TRUE)
 
-  game$add_control("Space", action = game$emit("dungeon_space"), input = input)
+  game$add_control(
+    "Space",
+    action = NULL,
+    input = input,
+    notify_server = TRUE
+  )
 
   inventory_text <- game$add_text(
     text = "weapon: none",

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -420,39 +420,12 @@ server <- function(input, output, session) {
       speed = motion_spec$speed * mushroom_approach_speed_multiplier,
       distance = motion_spec$distance * mushroom_approach_distance_multiplier,
       check_interval = mushroom_reaction_check_interval,
-      alert_duration = mushroom_alert_duration
+      alert_duration = mushroom_alert_duration,
+      wander_interval = motion_spec$interval
     )
-    force(enemy_name)
-    force(motion_spec)
-
-    shiny::observe({
-      shiny::invalidateLater(motion_spec$interval, session)
-
-      if (!isTRUE(enemy_is_alive[[enemy_name]]) || identical(enemy_in_range, enemy_name)) {
-        return(NULL)
-      }
-
-      direction <- sample(
-        list(c(-1, 0), c(1, 0), c(0, -1), c(0, 1)),
-        1
-      )[[1]]
-      enemies[[enemy_name]]$set_in_motion_random_or_toward(
-        target_name = "hero",
-        sight_range = mushroom_sight_range,
-        dir_x = direction[1],
-        dir_y = direction[2],
-        speed = motion_spec$speed,
-        distance = motion_spec$distance,
-        approach_speed_multiplier = mushroom_approach_speed_multiplier,
-        approach_distance_multiplier = mushroom_approach_distance_multiplier,
-        lag = motion_spec$lag
-      )
-    })
   })
 
-  game$add_control(
-    "Space",
-    action = function() {
+  shiny::observeEvent(input$phaser_dungeon_space, {
       if (life_points <= 0) return(invisible(NULL))
 
       if (sword_in_range && !has_sword) {
@@ -505,9 +478,10 @@ server <- function(input, output, session) {
       } else {
         play_hero_timed_animation(if (has_sword) "hero_sword_attack" else "hero_attack")
       }
-    },
-    input
-  )
+
+  }, ignoreInit = TRUE)
+
+  game$add_control("Space", action = game$emit("dungeon_space"), input = input)
 
   inventory_text <- game$add_text(
     text = "weapon: none",
@@ -570,8 +544,8 @@ server <- function(input, output, session) {
     x = 300,
     y = 300
   )
-  game$add_overlap("hero", "sword", input = input)
-  game$add_overlap_end("hero", "sword", input = input, session = session)
+  game$add_overlap("hero", "sword", input = input, notify_server = TRUE)
+  game$add_overlap_end("hero", "sword", input = input, session = session, notify_server = TRUE)
   shiny::observeEvent(input$overlap_hero_sword, {
     sword_in_range <<- TRUE
   }, ignoreInit = TRUE)
@@ -619,6 +593,7 @@ server <- function(input, output, session) {
     object_one = "hero",
     object_two = "wizard",
     input = input,
+    notify_server = TRUE,
     action = {
       talk_bubble_text$show()
       wizard$play_animation("talk", duration = 2000)
@@ -629,6 +604,7 @@ server <- function(input, output, session) {
     object_one = "hero",
     object_two = "wizard",
     input = input,
+    notify_server = TRUE,
     action = {
       talk_bubble_text$hide()
       wizard$play_animation("idle")
@@ -645,6 +621,7 @@ server <- function(input, output, session) {
     object_one = "hero",
     object_two = "mushroom_spirit",
     input = input,
+    notify_server = TRUE,
     action = mushroom_spirit$destroy()
   )
   shiny::observeEvent(input$overlap_hero_mushroom_spirit, {
@@ -663,7 +640,8 @@ server <- function(input, output, session) {
     game$add_overlap(
       object_one = "hero",
       object_two = enemy_name,
-      input = input
+      input = input,
+      notify_server = TRUE
     )
     overlap_event <- paste("overlap", "hero", enemy_name, sep = "_")
     shiny::observeEvent(input[[overlap_event]], {
@@ -706,7 +684,8 @@ server <- function(input, output, session) {
         enemy_animation_key(enemy_name, "idle")
       ),
       input = input,
-      session = session
+      session = session,
+      notify_server = TRUE
     )
     overlap_end_event <- paste("overlap_end", "hero", enemy_name, sep = "_")
     shiny::observeEvent(input[[overlap_end_event]], {

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -109,6 +109,8 @@ server <- function(input, output, session) {
   )
   enemy_attack_cooldown <- 2
   enemy_in_range <- NULL
+  sword_in_range <- FALSE
+  wizard_in_range <- FALSE
   has_sword <- FALSE
   hero_last_attack_time <- as.numeric(Sys.time()) - 1
   hero_attack_cooldown <- 0.75
@@ -450,7 +452,60 @@ server <- function(input, output, session) {
 
   game$add_control(
     "Space",
-    action = NULL,
+    action = function() {
+      if (life_points <= 0) return(invisible(NULL))
+
+      if (sword_in_range && !has_sword) {
+        has_sword <<- TRUE
+        sword_in_range <<- FALSE
+        sword$destroy()
+        inventory_text$set("weapon: sword")
+        hero$play_animation("hero_sword")
+        set_combat_status("You picked up the sword.")
+        return(invisible(NULL))
+      }
+
+      if (wizard_in_range) {
+        shinyalert::shinyalert(
+          title = "Dear, oh dear. What are you doing here in these dark forests, lad?",
+          type = "info",
+          callbackR = function(value) shinyalert::shinyalert(
+            title = "There is a good spirit waiting to be saved!",
+            type = "info"
+          )
+        )
+        return(invisible(NULL))
+      }
+
+      now <- as.numeric(Sys.time())
+      if (now - hero_last_attack_time < hero_attack_cooldown) return(invisible(NULL))
+      hero_last_attack_time <<- now
+      hero_attack_sound$play()
+
+      if (!is.null(enemy_in_range) && isTRUE(enemy_is_alive[[enemy_in_range]])) {
+        damage <- if (has_sword) hero_sword_damage else hero_fist_damage
+        hero_animation <- if (has_sword) "hero_sword_attack" else "hero_attack"
+        enemy_hit_points[[enemy_in_range]] <<- max(0, enemy_hit_points[[enemy_in_range]] - damage)
+        play_hero_timed_animation(hero_animation)
+        set_combat_status(sprintf(
+          "You hit %s for %d. Enemy life: %d/%d",
+          format_enemy_label(enemy_in_range), damage,
+          enemy_hit_points[[enemy_in_range]], enemy_max_hit_points[[enemy_in_range]]
+        ))
+
+        if (enemy_hit_points[[enemy_in_range]] <= 0) {
+          defeated <- enemy_in_range
+          enemy_is_alive[[defeated]] <<- FALSE
+          defeated_enemy_count <<- defeated_enemy_count + 1
+          enemies[[defeated]]$play_animation(enemy_animation_key(defeated, "destroy"), duration = 750)
+          later::later(function() enemies[[defeated]]$destroy(), delay = 0.75)
+          enemy_in_range <<- NULL
+        }
+        update_enemy_status()
+      } else {
+        play_hero_timed_animation(if (has_sword) "hero_sword_attack" else "hero_attack")
+      }
+    },
     input
   )
 
@@ -515,6 +570,14 @@ server <- function(input, output, session) {
     x = 300,
     y = 300
   )
+  game$add_overlap("hero", "sword", input = input)
+  game$add_overlap_end("hero", "sword", input = input, session = session)
+  shiny::observeEvent(input$overlap_hero_sword, {
+    sword_in_range <<- TRUE
+  }, ignoreInit = TRUE)
+  shiny::observeEvent(input$overlap_end_hero_sword, {
+    sword_in_range <<- FALSE
+  }, ignoreInit = TRUE)
 
 
   wizard <- game$add_sprite(
@@ -571,12 +634,28 @@ server <- function(input, output, session) {
       wizard$play_animation("idle")
     }
   )
+  shiny::observeEvent(input$overlap_hero_wizard, {
+    wizard_in_range <<- TRUE
+  }, ignoreInit = TRUE)
+  shiny::observeEvent(input$overlap_end_hero_wizard, {
+    wizard_in_range <<- FALSE
+  }, ignoreInit = TRUE)
 
   game$add_overlap(
     object_one = "hero",
     object_two = "mushroom_spirit",
-    input = input
+    input = input,
+    action = mushroom_spirit$destroy()
   )
+  shiny::observeEvent(input$overlap_hero_mushroom_spirit, {
+    shinyalert::shinyalert(
+      title = "Mushroom spirit saved!",
+      text = "The good spirit is safe. You win!",
+      type = "success",
+      closeOnClickOutside = FALSE,
+      showCancelButton = FALSE
+    )
+  }, ignoreInit = TRUE, once = TRUE)
 
   add_enemy_handlers <- function(enemy_name) {
     force(enemy_name)
@@ -584,25 +663,57 @@ server <- function(input, output, session) {
     game$add_overlap(
       object_one = "hero",
       object_two = enemy_name,
-      callback_fun = function(evt) {
-        enemy_in_range <<- enemy_name
-      },
       input = input
-  )
+    )
+    overlap_event <- paste("overlap", "hero", enemy_name, sep = "_")
+    shiny::observeEvent(input[[overlap_event]], {
+      enemy_in_range <<- enemy_name
+      now <- as.numeric(Sys.time())
+      if (life_points <= 0 || !isTRUE(enemy_is_alive[[enemy_name]]) ||
+          now - enemy_last_attack_time[[enemy_name]] < enemy_attack_cooldown) {
+        return(invisible(NULL))
+      }
+
+      enemy_last_attack_time[[enemy_name]] <<- now
+      life_points <<- max(0, life_points - enemy_damage[[enemy_name]])
+      enemies[[enemy_name]]$play_animation(
+        enemy_animation_key(enemy_name, "attack"),
+        duration = 1000
+      )
+      set_combat_status(sprintf(
+        "%s hits you for %d. Life: %d/%d",
+        format_enemy_label(enemy_name), enemy_damage[[enemy_name]],
+        life_points, max_life_points
+      ))
+      update_life_points()
+
+      if (life_points <= 0 && !game_over_shown) {
+        game_over_shown <<- TRUE
+        shinyalert::shinyalert(
+          title = "Game over",
+          text = "Your life points reached 0.",
+          type = "error",
+          closeOnClickOutside = FALSE,
+          showCancelButton = FALSE
+        )
+      }
+    }, ignoreInit = TRUE)
 
     game$add_overlap_end(
       object_one = "hero",
       object_two = enemy_name,
-      callback_fun = function(evt) {
+      action = enemies[[enemy_name]]$play_animation(
+        enemy_animation_key(enemy_name, "idle")
+      ),
+      input = input,
+      session = session
+    )
+    overlap_end_event <- paste("overlap_end", "hero", enemy_name, sep = "_")
+    shiny::observeEvent(input[[overlap_end_event]], {
         if (identical(enemy_in_range, enemy_name)) {
           enemy_in_range <<- NULL
         }
-        if (isTRUE(enemy_is_alive[[enemy_name]])) {
-          enemies[[enemy_name]]$play_animation(enemy_animation_key(enemy_name, "idle"))
-        }
-      },
-      input = input
-    )
+    }, ignoreInit = TRUE)
   }
 
   lapply(enemy_names, add_enemy_handlers)

--- a/inst/examples/hedgehog.R
+++ b/inst/examples/hedgehog.R
@@ -118,14 +118,8 @@ server <- function(input, output, session) {
     game$add_overlap(
       object_one = "hedgehog", 
       object_two = name, 
-      callback_fun = function(evt) {
-        if (!state$started || state$game_over || state$current_level != level_id) return(invisible(NULL))
-        state$game_over <- TRUE
-        shinyalert::shinyalert(
-          title = "Game over", text = paste0("A ", enemy_name, " caught the hedgehog. Try again!"), type = "error",
-          closeOnClickOutside = FALSE, showCancelButton = FALSE,
-          callbackR = function(value) session$reload()
-        )
+      action = {
+        hedgehog$destroy()
       }, input = input
     )
   }
@@ -184,29 +178,9 @@ server <- function(input, output, session) {
     game$add_overlap(
       object_one = "hedgehog", 
       group = paste0("apples_lvl", level_id), 
-      callback_fun = function(evt) {
-        if (!state$started || state$current_level != level_id || state$game_over) return(invisible(NULL))
-
-        apple_key <- paste(evt$x2, evt$y2, sep = ":")
-        if (isTRUE(state$collected[[apple_key]])) return(invisible(NULL))
-        state$collected[[apple_key]] <- TRUE
-
-        state$score <- state$score + 1
-        score_text$set(paste0("Level ", level_id, " score: ", state$score))
-        apples_group$disable(evt)
-
-        if (state$score >= nrow(cfg$apples)) {
-          pause_gameplay(level_id)
-          if (level_id < length(level_config)) {
-            passed_level_alert(level_id)
-          } else {
-            shinyalert::shinyalert(
-              title = "You won!", text = "Great job! You finished all levels and collected all apples.",
-              type = "success", closeOnClickOutside = FALSE, showCancelButton = FALSE,
-              callbackR = function(value) session$reload()
-            )
-          }
-        }
+      action = {
+        score_text$set(paste0("Level ", level_id, ": apple collected!"))
+        apples_group$disable()
     }, input = input)
 
     list(apples = apples_group, attackers = attackers)

--- a/inst/examples/hedgehog.R
+++ b/inst/examples/hedgehog.R
@@ -121,6 +121,7 @@ server <- function(input, output, session) {
     game$add_overlap(
       object_one = "hedgehog", 
       object_two = name, 
+      notify_server = TRUE,
       action = {
         score_text$set("Game over!")
       }, input = input
@@ -196,6 +197,7 @@ server <- function(input, output, session) {
     game$add_overlap(
       object_one = "hedgehog", 
       group = paste0("apples_lvl", level_id), 
+      notify_server = TRUE,
       action = {
         score_text$set(paste0("Level ", level_id, ": apple collected!"))
         apples_group$disable()
@@ -234,19 +236,19 @@ server <- function(input, output, session) {
   }
 
 
-  game$add_control("Space", action = function() {
-    if (!state$started || state$game_over || state$is_boosting) return(invisible(NULL))
-
-    state$is_boosting <- TRUE
+  boost_cooldown <- game$add_cooldown("hedgehog_boost", boost_duration * 1000)
+  game$add_control("Space", action = {
+    if (boost_cooldown$ready()) {
+      boost_cooldown$trigger()
     hedgehog$play_animation("hedgehog_run", duration = boost_duration * 1000)
     hedgehog$add_player_controls(directions = c("left", "right", "up", "down"), speed = boost_speed)
-
-    later::later(function() {
-      state$is_boosting <- FALSE
-      if (state$started && !state$game_over) {
-        hedgehog$add_player_controls(directions = c("left", "right", "up", "down"), speed = base_speed)
-      }
-    }, delay = boost_duration)
+      game$after(boost_duration * 1000, {
+        hedgehog$add_player_controls(
+          directions = c("left", "right", "up", "down"),
+          speed = base_speed
+        )
+      })
+    }
   }, input = input)
 
   state$levels[["1"]] <- init_level(1)

--- a/inst/examples/hedgehog.R
+++ b/inst/examples/hedgehog.R
@@ -115,13 +115,31 @@ server <- function(input, output, session) {
   }
 
   add_enemy_overlap <- function(name, level_id, enemy_name) {
+    force(name)
+    force(level_id)
+    force(enemy_name)
     game$add_overlap(
       object_one = "hedgehog", 
       object_two = name, 
       action = {
-        hedgehog$destroy()
+        score_text$set("Game over!")
       }, input = input
     )
+    enemy_event <- paste("overlap", "hedgehog", name, sep = "_")
+    shiny::observeEvent(input[[enemy_event]], {
+      if (!state$started || state$game_over || state$current_level != level_id) {
+        return(invisible(NULL))
+      }
+      state$game_over <- TRUE
+      shinyalert::shinyalert(
+        title = "Game over",
+        text = paste0("A ", enemy_name, " caught the hedgehog. Try again!"),
+        type = "error",
+        closeOnClickOutside = FALSE,
+        showCancelButton = FALSE,
+        callbackR = function(value) session$reload()
+      )
+    }, ignoreInit = TRUE)
   }
 
   pause_gameplay <- function(level_id = state$current_level) {
@@ -182,6 +200,35 @@ server <- function(input, output, session) {
         score_text$set(paste0("Level ", level_id, ": apple collected!"))
         apples_group$disable()
     }, input = input)
+    apple_event <- paste("overlap", "hedgehog", paste0("apples_lvl", level_id), sep = "_")
+    shiny::observeEvent(input[[apple_event]], {
+      evt <- input[[apple_event]]
+      if (!state$started || state$current_level != level_id || state$game_over) {
+        return(invisible(NULL))
+      }
+
+      apple_key <- paste(evt$x2, evt$y2, sep = ":")
+      if (isTRUE(state$collected[[apple_key]])) return(invisible(NULL))
+      state$collected[[apple_key]] <- TRUE
+      state$score <- state$score + 1
+      score_text$set(paste0("Level ", level_id, " score: ", state$score))
+
+      if (state$score >= nrow(cfg$apples)) {
+        pause_gameplay(level_id)
+        if (level_id < length(level_config)) {
+          passed_level_alert(level_id)
+        } else {
+          shinyalert::shinyalert(
+            title = "You won!",
+            text = "Great job! You finished all levels and collected all apples.",
+            type = "success",
+            closeOnClickOutside = FALSE,
+            showCancelButton = FALSE,
+            callbackR = function(value) session$reload()
+          )
+        }
+      }
+    }, ignoreInit = TRUE)
 
     list(apples = apples_group, attackers = attackers)
   }

--- a/inst/sample_app/app.R
+++ b/inst/sample_app/app.R
@@ -63,14 +63,15 @@ server <- function(input, output, session) {
   rocks$create(200, 300)
 
   score_text <- game$add_text(text = "Score: 0", id = "score", x = 20, y = 20)
+  browser_score <- game$add_state("sample_score", 0)
 
   game$add_overlap(
     object_one = "hedgehog",
     group = "apples",
-    callback_fun = function(evt) {
-      apples$disable(evt)
-      score(score() + 1)
-      score_text$set(paste("Score:", score()))
+    action = {
+      apples$disable()
+      browser_score$increment()
+      score_text$set(browser_score$value())
     },
     input = input
   )
@@ -94,12 +95,8 @@ server <- function(input, output, session) {
   game$add_overlap(
     object_one = "hedgehog",
     object_two = "badger",
-    callback_fun = function(evt) {
-      shinyalert::shinyalert(
-        title = "Game over", type = "error",
-        closeOnClickOutside = FALSE, showCancelButton = FALSE,
-        callbackR = function(value) session$reload()
-      )
+    action = {
+      game$alert(title = "Game over", type = "error")
     },
     input = input
   )

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -15,6 +15,7 @@ GameBridge.sounds = GameBridge.sounds || {};
 GameBridge.pendingSoundActions = GameBridge.pendingSoundActions || {};
 
 function sendPhaserEvent(target, payload) {
+  if (!target) return;
   if (typeof target === "string" && (/^https?:/.test(target) || target.includes("/")) && window.fetch) {
     window.fetch(target, {
       method: "POST",
@@ -388,16 +389,24 @@ function retryWhenMissingObjects(fn, objectNames) {
   return true;
 }
 
-function addOverlap(objectOneName, objectTwoName, inputId, browserActions = []) {
-  if (retryWhenMissingObjects(() => addOverlap(objectOneName, objectTwoName, inputId, browserActions), [objectOneName, objectTwoName])) return;
+function addOverlap(objectOneName, objectTwoName, inputId, browserActions = [], mode = "enter", interval = 0) {
+  if (retryWhenMissingObjects(() => addOverlap(objectOneName, objectTwoName, inputId, browserActions, mode, interval), [objectOneName, objectTwoName])) return;
 
   const objectOne = scene.children.getByName(objectOneName);
   const objectTwo = scene.children.getByName(objectTwoName);
+  let lastContact = -Infinity;
+  let lastRun = -Infinity;
   scene.physics.add.overlap(
     objectOne, objectTwo,
     function(obj1, obj2) {
-      runBrowserActionList(browserActions, obj1, obj2);
-      sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
+      const now = performance.now();
+      const entering = now - lastContact > 50;
+      lastContact = now;
+      if ((mode === "enter" && entering) || (mode === "stay" && now - lastRun >= interval)) {
+        lastRun = now;
+        runBrowserActionList(browserActions, obj1, obj2);
+        sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
+      }
     }
   );
 }
@@ -449,18 +458,27 @@ function addOverlapEnd(objectOneName, objectTwoName, inputId, browserActions = [
   });
 }
 
-function addGroupOverlap(objectName, groupName, inputId, browserActions = []) {
+function addGroupOverlap(objectName, groupName, inputId, browserActions = [], mode = "enter", interval = 0) {
   if (!scene.children.getByName(objectName) || !scene[groupName]) {
-    window.setTimeout(() => addGroupOverlap(objectName, groupName, inputId, browserActions), 100);
+    window.setTimeout(() => addGroupOverlap(objectName, groupName, inputId, browserActions, mode, interval), 100);
     return;
   }
   const objectOne = scene.children.getByName(objectName);
   const objectTwo = scene[groupName];
+  const contacts = new WeakMap();
+  const runs = new WeakMap();
   scene.physics.add.overlap(
     objectOne, objectTwo,
     function(obj1, obj2) {
-      runBrowserActionList(browserActions, obj1, obj2);
-      sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
+      const now = performance.now();
+      const entering = now - (contacts.get(obj2) ?? -Infinity) > 50;
+      contacts.set(obj2, now);
+      if ((mode === "enter" && entering) ||
+          (mode === "stay" && now - (runs.get(obj2) ?? -Infinity) >= interval)) {
+        runs.set(obj2, now);
+        runBrowserActionList(browserActions, obj1, obj2);
+        sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
+      }
     }
   );
 }

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -83,6 +83,12 @@ function initPhaserGame(containerId, config) {
   function create() {
     cursors = this.input.keyboard.createCursorKeys();
     applyWorldBounds(GameBridge.pendingWorldBounds);
+    const unlockAudio = () => {
+      const context = this.sound && this.sound.context;
+      if (context && context.state === "suspended") context.resume();
+    };
+    this.input.keyboard.once("keydown", unlockAudio);
+    this.input.once("pointerdown", unlockAudio);
   }
 
   function update(time, delta) {
@@ -185,7 +191,12 @@ function playSound(name, volume = null, loop = null) {
     const config = {};
     if (volume !== null) config.volume = volume;
     if (loop !== null) config.loop = loop;
-    sound.play(config);
+    const context = scene && scene.sound && scene.sound.context;
+    if (context && context.state === "suspended") {
+      context.resume().then(() => sound.play(config));
+    } else {
+      sound.play(config);
+    }
   });
 }
 

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -13,7 +13,6 @@ GameBridge.lastHeroOverlapState = GameBridge.lastHeroOverlapState || "";
 GameBridge.nextHeroOverlapSendAt = GameBridge.nextHeroOverlapSendAt || 0;
 GameBridge.sounds = GameBridge.sounds || {};
 GameBridge.pendingSoundActions = GameBridge.pendingSoundActions || {};
-GameBridge.clientState = GameBridge.clientState || {};
 
 function sendPhaserEvent(target, payload) {
   if (typeof target === "string" && (/^https?:/.test(target) || target.includes("/")) && window.fetch) {
@@ -60,7 +59,6 @@ function playTypeAnim(sprite, type, suffix) {
 
 function initPhaserGame(containerId, config) {
   GameBridge.overlapEndWatchers = {};
-  GameBridge.clientState = {};
 
   window.game = new Phaser.Game({
     type: Phaser.AUTO,
@@ -358,23 +356,25 @@ function addPlayerTerrainCollider(spriteName) {
   scene.physics.add.collider(sprite, scene.terrainLayer);
 }
 
-function addCollider(objectOneName, objectTwoName, inputId) {
+function addCollider(objectOneName, objectTwoName, inputId, browserActions = []) {
   const objectOne = scene.children.getByName(objectOneName);
   const objectTwo = scene.children.getByName(objectTwoName);
   scene.physics.add.collider(
     objectOne, objectTwo,
     function(obj1, obj2) {
+      runBrowserActionList(browserActions);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );
 }
 
-function addGroupCollider(objectName, groupName, inputId) {
+function addGroupCollider(objectName, groupName, inputId, browserActions = []) {
   const objectOne = scene.children.getByName(objectName);
   const objectTwo = scene[groupName];
   scene.physics.add.collider(
     objectOne, objectTwo,
     function(obj1, obj2) {
+      runBrowserActionList(browserActions);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );
@@ -388,15 +388,15 @@ function retryWhenMissingObjects(fn, objectNames) {
   return true;
 }
 
-function addOverlap(objectOneName, objectTwoName, inputId, clientActions = []) {
-  if (retryWhenMissingObjects(() => addOverlap(objectOneName, objectTwoName, inputId, clientActions), [objectOneName, objectTwoName])) return;
+function addOverlap(objectOneName, objectTwoName, inputId, browserActions = []) {
+  if (retryWhenMissingObjects(() => addOverlap(objectOneName, objectTwoName, inputId, browserActions), [objectOneName, objectTwoName])) return;
 
   const objectOne = scene.children.getByName(objectOneName);
   const objectTwo = scene.children.getByName(objectTwoName);
   scene.physics.add.overlap(
     objectOne, objectTwo,
     function(obj1, obj2) {
-      runClientActionList(inputId, clientActions);
+      runBrowserActionList(browserActions);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );
@@ -423,8 +423,8 @@ function areOverlap(objectOneName, objectTwoName, inputId) {
   }
 };
 
-function addOverlapEnd(objectOneName, objectTwoName, inputId, clientActions = []) {
-  if (retryWhenMissingObjects(() => addOverlapEnd(objectOneName, objectTwoName, inputId, clientActions), [objectOneName, objectTwoName])) return;
+function addOverlapEnd(objectOneName, objectTwoName, inputId, browserActions = []) {
+  if (retryWhenMissingObjects(() => addOverlapEnd(objectOneName, objectTwoName, inputId, browserActions), [objectOneName, objectTwoName])) return;
 
   const obj1 = scene.children.getByName(objectOneName);
   const obj2 = scene.children.getByName(objectTwoName);
@@ -441,7 +441,7 @@ function addOverlapEnd(objectOneName, objectTwoName, inputId, clientActions = []
     );
 
     if (wasOverlapping && !currentlyOverlapping) {
-      runClientActionList(inputId, clientActions);
+      runBrowserActionList(browserActions);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
 
@@ -449,9 +449,9 @@ function addOverlapEnd(objectOneName, objectTwoName, inputId, clientActions = []
   });
 }
 
-function addGroupOverlap(objectName, groupName, inputId, clientActions = []) {
+function addGroupOverlap(objectName, groupName, inputId, browserActions = []) {
   if (!scene.children.getByName(objectName) || !scene[groupName]) {
-    window.setTimeout(() => addGroupOverlap(objectName, groupName, inputId, clientActions), 100);
+    window.setTimeout(() => addGroupOverlap(objectName, groupName, inputId, browserActions), 100);
     return;
   }
   const objectOne = scene.children.getByName(objectName);
@@ -459,7 +459,7 @@ function addGroupOverlap(objectName, groupName, inputId, clientActions = []) {
   scene.physics.add.overlap(
     objectOne, objectTwo,
     function(obj1, obj2) {
-      runClientActionList(inputId, clientActions);
+      runBrowserActionList(browserActions);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -362,7 +362,7 @@ function addCollider(objectOneName, objectTwoName, inputId, browserActions = [])
   scene.physics.add.collider(
     objectOne, objectTwo,
     function(obj1, obj2) {
-      runBrowserActionList(browserActions);
+      runBrowserActionList(browserActions, obj1, obj2);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );
@@ -374,7 +374,7 @@ function addGroupCollider(objectName, groupName, inputId, browserActions = []) {
   scene.physics.add.collider(
     objectOne, objectTwo,
     function(obj1, obj2) {
-      runBrowserActionList(browserActions);
+      runBrowserActionList(browserActions, obj1, obj2);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );
@@ -396,7 +396,7 @@ function addOverlap(objectOneName, objectTwoName, inputId, browserActions = []) 
   scene.physics.add.overlap(
     objectOne, objectTwo,
     function(obj1, obj2) {
-      runBrowserActionList(browserActions);
+      runBrowserActionList(browserActions, obj1, obj2);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );
@@ -441,7 +441,7 @@ function addOverlapEnd(objectOneName, objectTwoName, inputId, browserActions = [
     );
 
     if (wasOverlapping && !currentlyOverlapping) {
-      runBrowserActionList(browserActions);
+      runBrowserActionList(browserActions, obj1, obj2);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
 
@@ -459,7 +459,7 @@ function addGroupOverlap(objectName, groupName, inputId, browserActions = []) {
   scene.physics.add.overlap(
     objectOne, objectTwo,
     function(obj1, obj2) {
-      runBrowserActionList(browserActions);
+      runBrowserActionList(browserActions, obj1, obj2);
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -177,13 +177,13 @@ function addSound(name, url, volume = 1, loop = false) {
   }
 
   scene.load.audio(name, url);
-  scene.load.once('complete', () => {
+  scene.load.once(`filecomplete-audio-${name}`, () => {
     if (GameBridge.sounds[name]) return;
 
     GameBridge.sounds[name] = scene.sound.add(name, { volume, loop });
     applyPendingSoundActions(name);
   });
-  scene.load.start();
+  if (!scene.load.isLoading()) scene.load.start();
 }
 
 function playSound(name, volume = null, loop = null) {
@@ -369,6 +369,10 @@ function addPlayerTerrainCollider(spriteName) {
 }
 
 function addCollider(objectOneName, objectTwoName, inputId, browserActions = []) {
+  if (retryWhenMissingObjects(
+    () => addCollider(objectOneName, objectTwoName, inputId, browserActions),
+    [objectOneName, objectTwoName]
+  )) return;
   const objectOne = scene.children.getByName(objectOneName);
   const objectTwo = scene.children.getByName(objectTwoName);
   scene.physics.add.collider(
@@ -381,6 +385,10 @@ function addCollider(objectOneName, objectTwoName, inputId, browserActions = [])
 }
 
 function addGroupCollider(objectName, groupName, inputId, browserActions = []) {
+  if (!scene.children.getByName(objectName) || !scene[groupName]) {
+    window.setTimeout(() => addGroupCollider(objectName, groupName, inputId, browserActions), 100);
+    return;
+  }
   const objectOne = scene.children.getByName(objectName);
   const objectTwo = scene[groupName];
   scene.physics.add.collider(

--- a/inst/www/phaser-groups.js
+++ b/inst/www/phaser-groups.js
@@ -1,3 +1,6 @@
+window.GameBridge = window.GameBridge || {};
+GameBridge.pendingGroupMembers = GameBridge.pendingGroupMembers || {};
+
 function addGroup(name) {
   if (!scene[name]) {
     scene[name] = scene.physics.add.group();
@@ -9,7 +12,7 @@ function addGroupAnimation(groupName, suffix, url, w, h, totalFrames, rate) {
     frameWidth: w, frameHeight: h, endFrame: totalFrames - 1
   });
 
-  scene.load.once('complete', () => {
+  scene.load.once(`filecomplete-spritesheet-${groupName}`, () => {
     scene.anims.create({
       key: `${groupName}_${suffix}`,
       frames: scene.anims.generateFrameNumbers(groupName, { start: 0, end: totalFrames - 1 }),
@@ -17,10 +20,15 @@ function addGroupAnimation(groupName, suffix, url, w, h, totalFrames, rate) {
       repeat: -1
     });
   });
-  scene.load.start();
+  if (!scene.load.isLoading()) scene.load.start();
 }
 
 function addToGroup(groupName, x, y) {
+  if (!scene.textures.exists(groupName)) {
+    GameBridge.pendingGroupMembers[groupName] = GameBridge.pendingGroupMembers[groupName] || [];
+    GameBridge.pendingGroupMembers[groupName].push({ x, y });
+    return;
+  }
   const sprite = scene[groupName].create(x, y, groupName);
   playTypeAnim(sprite, groupName, "idle");
 }
@@ -30,9 +38,12 @@ function addStaticGroup(name, url) {
     scene[name] = scene.physics.add.staticGroup();
   }
   scene.load.image(name, url);
-  scene.load.once('complete', () => {
+  scene.load.once(`filecomplete-image-${name}`, () => {
+    const pending = GameBridge.pendingGroupMembers[name] || [];
+    pending.forEach(({ x, y }) => addToGroup(name, x, y));
+    delete GameBridge.pendingGroupMembers[name];
   });
-  scene.load.start();
+  if (!scene.load.isLoading()) scene.load.start();
 }
 
 function disableBody(groupName, x, y) {

--- a/inst/www/phaser-image.js
+++ b/inst/www/phaser-image.js
@@ -1,7 +1,7 @@
 function addImage(imageName, imageUrl, x = null, y = null, visible = true, clickable = true) {
   scene.load.image(imageName, imageUrl);
 
-  scene.load.once('complete', () => {
+  scene.load.once(`filecomplete-image-${imageName}`, () => {
     const px = x !== null
       ? x
       : scene.cameras.main.width  / 2;
@@ -23,7 +23,7 @@ function addImage(imageName, imageUrl, x = null, y = null, visible = true, click
     }
   });
 
-  scene.load.start();
+  if (!scene.load.isLoading()) scene.load.start();
 }
 
 function showImage(imageName) {

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -497,13 +497,16 @@ function startSpriteApproachOnSight(
         color: "#ffeb3b",
         stroke: "#000000",
         strokeThickness: 4
-      }).setOrigin(0.5);
+      }).setOrigin(0.5).setDepth(10000);
       scene.tweens.add({
         targets: alertText,
-        y: alertText.y - 24,
         alpha: 0,
         duration: alertDuration,
         ease: "Cubic.easeOut",
+        onUpdate: () => {
+          if (!sprite || !sprite.active) return;
+          alertText.setPosition(sprite.x, sprite.y - sprite.displayHeight * 0.6);
+        },
         onComplete: () => alertText.destroy()
       });
       return;

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -226,7 +226,7 @@ function normalizeBrowserActions(actions) {
   return Array.isArray(actions) ? actions : [actions];
 }
 
-function runBrowserAction(action) {
+function runBrowserAction(action, overlapObjectOne, overlapObjectTwo) {
   if (action.play_sound) playSound(action.play_sound, action.volume ?? null, action.loop ?? null);
   if (action.pause_sound) pauseSound(action.pause_sound);
   if (action.resume_sound) resumeSound(action.resume_sound);
@@ -242,6 +242,13 @@ function runBrowserAction(action) {
   }
 
   if (action.destroy_sprite) destroySprite(action.destroy_sprite);
+  if (action.set_in_motion) {
+    const motion = action.set_in_motion;
+    setSpriteInMotion(motion.name, motion.dir_x, motion.dir_y, motion.speed, motion.distance);
+  }
+  if (action.disable_overlap_member && overlapObjectTwo) {
+    disableBody(action.disable_overlap_member, overlapObjectTwo.x, overlapObjectTwo.y);
+  }
   if (action.set_text && action.set_text.id !== undefined) {
     setText(action.set_text.text || "", action.set_text.id);
   }
@@ -249,8 +256,10 @@ function runBrowserAction(action) {
   if (action.hide_text) hideText(action.hide_text);
 }
 
-function runBrowserActionList(actions) {
-  normalizeBrowserActions(actions).forEach(runBrowserAction);
+function runBrowserActionList(actions, overlapObjectOne, overlapObjectTwo) {
+  normalizeBrowserActions(actions).forEach((action) => {
+    runBrowserAction(action, overlapObjectOne, overlapObjectTwo);
+  });
 }
 
 function addKeyControl(key) {

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -55,7 +55,7 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
     frameHeight: frameHeight
   });
 
-  scene.load.once('complete', () => {
+  scene.load.once(`filecomplete-spritesheet-${name}`, () => {
     const resolvedFrameCount = resolveFrameCount(name, frameWidth, frameHeight, frameCount);
 
     scene.anims.create({
@@ -86,12 +86,12 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
     }
   });
 
-  scene.load.start();
+  if (!scene.load.isLoading()) scene.load.start();
 }
 
 function addStaticSprite(name, url, x, y) {
   scene.load.image(name, url);
-  scene.load.once('complete', () => {
+  scene.load.once(`filecomplete-image-${name}`, () => {
     const staticSprite = scene.physics.add.staticSprite(x, y, name).setName(name);
     if (scene.terrainLayer) {
       scene.physics.add.collider(staticSprite, scene.terrainLayer);
@@ -108,7 +108,7 @@ function addStaticSprite(name, url, x, y) {
       applyPendingTerrainColliders();
     }
   });
-  scene.load.start();
+  if (!scene.load.isLoading()) scene.load.start();
 }
 
 function addSpriteAnimation(name, suffix, url, frameWidth, frameHeight, frameCount, frameRate) {
@@ -121,7 +121,7 @@ function addSpriteAnimation(name, suffix, url, frameWidth, frameHeight, frameCou
     frameWidth:  frameWidth,
     frameHeight: frameHeight
   });
-  scene.load.once("complete", () => {
+  scene.load.once(`filecomplete-spritesheet-${animKey}`, () => {
     const resolvedFrameCount = resolveFrameCount(animKey, frameWidth, frameHeight, frameCount);
 
     scene.anims.create({
@@ -134,7 +134,7 @@ function addSpriteAnimation(name, suffix, url, frameWidth, frameHeight, frameCou
       repeat: -1
     });
   });
-  scene.load.start();
+  if (!scene.load.isLoading()) scene.load.start();
 }
 
 

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -4,6 +4,8 @@ GameBridge.forcedAnimations = GameBridge.forcedAnimations || {};
 GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
 GameBridge.pendingScrollFactor = GameBridge.pendingScrollFactor || {};
 GameBridge.pendingSpriteActions = GameBridge.pendingSpriteActions || {};
+GameBridge.browserState = GameBridge.browserState || {};
+GameBridge.cooldowns = GameBridge.cooldowns || {};
 
 
 
@@ -226,7 +228,63 @@ function normalizeBrowserActions(actions) {
   return Array.isArray(actions) ? actions : [actions];
 }
 
+function setBrowserState(key, value) { GameBridge.browserState[key] = value; }
+function resolveBrowserValue(value) {
+  return value && typeof value === "object" && value.state !== undefined
+    ? GameBridge.browserState[value.state]
+    : value;
+}
+function browserObject(name) { return scene && scene.children.getByName(name); }
+function browserCondition(condition) {
+  if (!condition) return true;
+  if (condition.op === "&&") return browserCondition(condition.left) && browserCondition(condition.right);
+  if (condition.op === "||") return browserCondition(condition.left) || browserCondition(condition.right);
+  if (condition.op === "!") return !browserCondition(condition.value);
+  if (condition.op === "exists") return Boolean(browserObject(condition.object)?.active);
+  if (condition.op === "overlaps") {
+    const a = browserObject(condition.objects[0]);
+    const b = browserObject(condition.objects[1]);
+    return Boolean(a && b && Phaser.Geom.Intersects.RectangleToRectangle(a.getBounds(), b.getBounds()));
+  }
+  if (condition.op === "is_true") return Boolean(GameBridge.browserState[condition.state]);
+  if (condition.op === "is_false") return !GameBridge.browserState[condition.state];
+  if (condition.op === "cooldown_ready") {
+    return performance.now() - (GameBridge.cooldowns[condition.key] ?? -Infinity) >= condition.duration;
+  }
+  const left = resolveBrowserValue(condition.left);
+  const right = resolveBrowserValue(condition.right);
+  if (condition.op === "==") return left === right;
+  if (condition.op === "!=") return left !== right;
+  if (condition.op === "<") return left < right;
+  if (condition.op === "<=") return left <= right;
+  if (condition.op === ">") return left > right;
+  if (condition.op === ">=") return left >= right;
+  return false;
+}
+
 function runBrowserAction(action, overlapObjectOne, overlapObjectTwo) {
+  if (action.after) {
+    window.setTimeout(() => runBrowserActionList(
+      action.after.actions, overlapObjectOne, overlapObjectTwo
+    ), Number(resolveBrowserValue(action.after.delay)));
+    return;
+  }
+  if (action.if) {
+    runBrowserActionList(
+      browserCondition(action.if.condition) ? action.if.then : action.if.else,
+      overlapObjectOne, overlapObjectTwo
+    );
+    return;
+  }
+  if (action.state_action) {
+    const state = action.state_action;
+    const current = GameBridge.browserState[state.key];
+    const value = resolveBrowserValue(state.value);
+    if (state.op === "set") GameBridge.browserState[state.key] = value;
+    else if (state.op === "increment" || state.op === "add") GameBridge.browserState[state.key] = Number(current || 0) + Number(value);
+    else GameBridge.browserState[state.key] = Number(current || 0) - Number(value);
+  }
+  if (action.cooldown_trigger) GameBridge.cooldowns[action.cooldown_trigger] = performance.now();
   if (action.play_sound) playSound(action.play_sound, action.volume ?? null, action.loop ?? null);
   if (action.pause_sound) pauseSound(action.pause_sound);
   if (action.resume_sound) resumeSound(action.resume_sound);
@@ -246,14 +304,26 @@ function runBrowserAction(action, overlapObjectOne, overlapObjectTwo) {
     const motion = action.set_in_motion;
     setSpriteInMotion(motion.name, motion.dir_x, motion.dir_y, motion.speed, motion.distance);
   }
+  if (action.set_velocity_x) setVelocityX(action.set_velocity_x.name, action.set_velocity_x.value);
+  if (action.set_velocity_y) setVelocityY(action.set_velocity_y.name, action.set_velocity_y.value);
+  if (action.player_controls) {
+    addPlayerControls(action.player_controls.name, action.player_controls.directions, action.player_controls.speed);
+  }
   if (action.disable_overlap_member && overlapObjectTwo) {
     disableBody(action.disable_overlap_member, overlapObjectTwo.x, overlapObjectTwo.y);
   }
   if (action.set_text && action.set_text.id !== undefined) {
-    setText(action.set_text.text || "", action.set_text.id);
+    setText(String(resolveBrowserValue(action.set_text.text) ?? ""), action.set_text.id);
   }
   if (action.show_text) showText(action.show_text);
   if (action.hide_text) hideText(action.hide_text);
+  if (action.show_alert) {
+    if (typeof swal === "function") swal(action.show_alert);
+    else window.alert(action.show_alert.title || action.show_alert.text || "");
+  }
+  if (action.emit) {
+    Shiny.setInputValue("phaser_" + action.emit.name, action.emit.data || {}, { priority: "event" });
+  }
 }
 
 function runBrowserActionList(actions, overlapObjectOne, overlapObjectTwo) {
@@ -262,16 +332,15 @@ function runBrowserActionList(actions, overlapObjectOne, overlapObjectTwo) {
   });
 }
 
-function addKeyControl(key) {
+function addKeyControl(key, browserActions = [], notifyServer = false) {
   if (GameBridge.keyControlHandlers[key]) return;
 
   const handler = function(e) {
     if (key === e.code) {
-      Shiny.setInputValue(
-        key + "_action",
-        { code: e.code, evt_nonce: Date.now() + Math.random() },
-        { priority: "event" }
-      );
+      runBrowserActionList(browserActions);
+      if (notifyServer) {
+        Shiny.setInputValue(key + "_action", { code: e.code, evt_nonce: Date.now() + Math.random() }, { priority: "event" });
+      }
     }
   };
 
@@ -389,7 +458,8 @@ function startSpriteApproachOnSight(
   speed,
   distance,
   checkInterval = 250,
-  alertDuration = 1200
+  alertDuration = 1200,
+  wanderInterval = 1500
 ) {
   if (!GameBridge.sightApproachIntervals) GameBridge.sightApproachIntervals = {};
   if (GameBridge.sightApproachIntervals[name]) {
@@ -405,6 +475,12 @@ function startSpriteApproachOnSight(
     if (targetDistance <= 0 || targetDistance > sightRange) {
       if (sprite.getData && sprite.getData("sightAlert")) {
         sprite.setData("sightAlert", null);
+      }
+      const lastWander = sprite.getData("lastWander") || 0;
+      if (performance.now() - lastWander >= wanderInterval) {
+        sprite.setData("lastWander", performance.now());
+        const direction = Phaser.Math.RND.pick([[1, 0], [-1, 0], [0, 1], [0, -1]]);
+        setSpriteInMotion(name, direction[0], direction[1], speed, distance);
       }
       return;
     }

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -1,12 +1,9 @@
 window.GameBridge = window.GameBridge || {};
 GameBridge.keyControlHandlers = GameBridge.keyControlHandlers || {};
-GameBridge.keyControlActions = GameBridge.keyControlActions || {};
-GameBridge.keyControlLastRun = GameBridge.keyControlLastRun || {};
 GameBridge.forcedAnimations = GameBridge.forcedAnimations || {};
 GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
 GameBridge.pendingScrollFactor = GameBridge.pendingScrollFactor || {};
 GameBridge.pendingSpriteActions = GameBridge.pendingSpriteActions || {};
-GameBridge.clientState = GameBridge.clientState || {};
 
 
 
@@ -224,383 +221,45 @@ function disableSprite(name) {
   }
 }
 
-function getClientObject(name) {
-  return scene && scene.children && scene.children.getByName(name);
+function normalizeBrowserActions(actions) {
+  if (!actions || (Array.isArray(actions) && actions.length === 0)) return [];
+  return Array.isArray(actions) ? actions : [actions];
 }
 
-function objectExists(name) {
-  const object = getClientObject(name);
-  return Boolean(object && object.active !== false);
-}
-
-function objectsOverlap(objectNames) {
-  if (!Array.isArray(objectNames) || objectNames.length !== 2) return false;
-
-  const objectOne = getClientObject(objectNames[0]);
-  const objectTwo = getClientObject(objectNames[1]);
-  if (!objectOne || !objectTwo || !objectOne.getBounds || !objectTwo.getBounds) {
-    return false;
-  }
-
-  return Phaser.Geom.Intersects.RectangleToRectangle(
-    objectOne.getBounds(),
-    objectTwo.getBounds()
-  );
-}
-
-
-function normalizeStateKey(key) {
-  return String(key || "");
-}
-
-function ensureClientState() {
-  window.GameBridge = window.GameBridge || {};
-  GameBridge.clientState = GameBridge.clientState || {};
-  return GameBridge.clientState;
-}
-
-function getClientState(key) {
-  return ensureClientState()[normalizeStateKey(key)];
-}
-
-function setClientState(key, value) {
-  ensureClientState()[normalizeStateKey(key)] = value;
-  return value;
-}
-
-function clampNumber(value, min, max) {
-  let nextValue = Number(value);
-  if (!Number.isFinite(nextValue)) nextValue = 0;
-  if (Number.isFinite(Number(min))) nextValue = Math.max(Number(min), nextValue);
-  if (Number.isFinite(Number(max))) nextValue = Math.min(Number(max), nextValue);
-  return nextValue;
-}
-
-function applyStateAction(stateAction) {
-  if (!stateAction || stateAction.key === undefined) return;
-
-  const key = normalizeStateKey(stateAction.key);
-  const op = stateAction.op || "set";
-  const currentValue = Number(getClientState(key) ?? 0);
-  const amount = Number(stateAction.amount ?? stateAction.value ?? 0);
-  let nextValue;
-
-  if (op === "initialize" || op === "init") {
-    if (getClientState(key) !== undefined) return;
-    nextValue = amount;
-  } else if (op === "increment" || op === "add") {
-    nextValue = currentValue + amount;
-  } else if (op === "decrement" || op === "subtract") {
-    nextValue = currentValue - amount;
-  } else {
-    nextValue = amount;
-  }
-
-  setClientState(key, clampNumber(nextValue, stateAction.min, stateAction.max));
-}
-
-function interpolateClientStateText(text) {
-  return String(text || "").replace(/\{state\.([^}]+)\}/g, (_match, key) => {
-    const value = getClientState(key);
-    return value === undefined ? "" : String(value);
-  });
-}
-
-function stateConditionPasses(condition) {
-  if (!condition || condition.key === undefined) return true;
-
-  const actual = Number(getClientState(condition.key) ?? 0);
-  const value = Number(condition.value ?? 0);
-  const op = condition.op || "eq";
-
-  if (op === "lte") return actual <= value;
-  if (op === "lt") return actual < value;
-  if (op === "gte") return actual >= value;
-  if (op === "gt") return actual > value;
-  if (op === "neq") return actual !== value;
-  return actual === value;
-}
-
-function actionConditionPasses(action) {
-  if (action.when_overlap && !objectsOverlap(action.when_overlap)) return false;
-
-  if (action.when_state && !stateConditionPasses(action.when_state)) return false;
-
-  if (action.when_exists) {
-    const existsConditions = Array.isArray(action.when_exists)
-      ? action.when_exists
-      : [action.when_exists];
-
-    const allExist = existsConditions.every((condition) => {
-      if (typeof condition === "string") return objectExists(condition);
-      if (condition && typeof condition === "object") {
-        return objectExists(condition.name) === Boolean(condition.exists);
-      }
-      return false;
-    });
-
-    if (!allExist) return false;
-  }
-
-  return true;
-}
-
-function normalizeClientActions(clientActions) {
-  if (!clientActions || (Array.isArray(clientActions) && clientActions.length === 0)) {
-    return [];
-  }
-  return Array.isArray(clientActions) ? clientActions : [clientActions];
-}
-
-function getClientObject(name) {
-  return scene && scene.children && scene.children.getByName(name);
-}
-
-function objectExists(name) {
-  const object = getClientObject(name);
-  return Boolean(object && object.active !== false);
-}
-
-function objectsOverlap(objectNames) {
-  if (!Array.isArray(objectNames) || objectNames.length !== 2) return false;
-  const objectOne = getClientObject(objectNames[0]);
-  const objectTwo = getClientObject(objectNames[1]);
-  if (!objectOne || !objectTwo || !objectOne.getBounds || !objectTwo.getBounds) return false;
-  return Phaser.Geom.Intersects.RectangleToRectangle(objectOne.getBounds(), objectTwo.getBounds());
-}
-
-function ensureClientState() {
-  window.GameBridge = window.GameBridge || {};
-  GameBridge.clientState = GameBridge.clientState || {};
-  return GameBridge.clientState;
-}
-
-function getClientState(key) {
-  return ensureClientState()[String(key || "")];
-}
-
-function setClientState(key, value) {
-  ensureClientState()[String(key || "")] = value;
-  return value;
-}
-
-function clampNumber(value, min, max) {
-  let nextValue = Number(value);
-  if (!Number.isFinite(nextValue)) nextValue = 0;
-  if (Number.isFinite(Number(min))) nextValue = Math.max(Number(min), nextValue);
-  if (Number.isFinite(Number(max))) nextValue = Math.min(Number(max), nextValue);
-  return nextValue;
-}
-
-function applyStateAction(stateAction) {
-  if (!stateAction || stateAction.key === undefined) return;
-  const key = String(stateAction.key || "");
-  const op = stateAction.op || "set";
-  const currentValue = Number(getClientState(key) ?? 0);
-  const amount = Number(stateAction.amount ?? stateAction.value ?? 0);
-  let nextValue;
-  if (op === "initialize" || op === "init") {
-    if (getClientState(key) !== undefined) return;
-    nextValue = amount;
-  } else if (op === "increment" || op === "add") {
-    nextValue = currentValue + amount;
-  } else if (op === "decrement" || op === "subtract") {
-    nextValue = currentValue - amount;
-  } else {
-    nextValue = amount;
-  }
-  setClientState(key, clampNumber(nextValue, stateAction.min, stateAction.max));
-}
-
-function interpolateClientStateText(text) {
-  return String(text || "").replace(/\{state\.([^}]+)\}/g, (_match, key) => {
-    const value = getClientState(key);
-    return value === undefined ? "" : String(value);
-  });
-}
-
-function stateConditionPasses(condition) {
-  if (!condition || condition.key === undefined) return true;
-  const actual = Number(getClientState(condition.key) ?? 0);
-  const value = Number(condition.value ?? 0);
-  const op = condition.op || "eq";
-  if (op === "lte") return actual <= value;
-  if (op === "lt") return actual < value;
-  if (op === "gte") return actual >= value;
-  if (op === "gt") return actual > value;
-  if (op === "neq") return actual !== value;
-  return actual === value;
-}
-
-function actionConditionPasses(action) {
-  if (action.when_overlap && !objectsOverlap(action.when_overlap)) return false;
-  if (action.when_state && !stateConditionPasses(action.when_state)) return false;
-  if (action.when_exists) {
-    const existsConditions = Array.isArray(action.when_exists) ? action.when_exists : [action.when_exists];
-    const allExist = existsConditions.every((condition) => {
-      if (typeof condition === "string") return objectExists(condition);
-      if (condition && typeof condition === "object") {
-        return objectExists(condition.name) === Boolean(condition.exists);
-      }
-      return false;
-    });
-    if (!allExist) return false;
-  }
-  return true;
-}
-
-function normalizeClientActions(clientActions) {
-  if (!clientActions || (Array.isArray(clientActions) && clientActions.length === 0)) return [];
-  return Array.isArray(clientActions) ? clientActions : [clientActions];
-}
-
-function showClientAlert(alertOptions) {
-  const options = typeof alertOptions === "string" ? { title: alertOptions } : alertOptions || {};
-  if (typeof swal === "function") { swal(options); return; }
-  if (typeof sweetAlert === "function") { sweetAlert(options); return; }
-  window.alert(options.title || options.text || "");
-}
-
-function runClientAction(key, action) {
-  if (!actionConditionPasses(action)) return false;
-
-  const cooldown = Number(action.cooldown || 0);
-  if (cooldown > 0) {
-    const cooldownKey = key + "::" + JSON.stringify(action);
-    const now = performance.now();
-    const lastRun = GameBridge.keyControlLastRun[cooldownKey];
-    if (lastRun !== undefined && (now - lastRun) < cooldown) return false;
-    GameBridge.keyControlLastRun[cooldownKey] = now;
-  }
-
-  if (action.set_state) {
-    const stateActions = Array.isArray(action.set_state) ? action.set_state : [action.set_state];
-    stateActions.forEach(applyStateAction);
-  }
-
-  if (action.raw_js) {
-    const snippets = Array.isArray(action.raw_js) ? action.raw_js : [action.raw_js];
-    for (const snippet of snippets) {
-      eval(snippet);
-    }
-  }
-
-  if (action.play_sound) {
-    playSound(action.play_sound, action.volume ?? null, action.loop ?? null);
-  }
+function runBrowserAction(action) {
+  if (action.play_sound) playSound(action.play_sound, action.volume ?? null, action.loop ?? null);
+  if (action.pause_sound) pauseSound(action.pause_sound);
+  if (action.resume_sound) resumeSound(action.resume_sound);
+  if (action.stop_sound) stopSound(action.stop_sound);
 
   if (action.play_animation) {
     const spriteName = action.sprite || action.name;
-    if (!spriteName) {
-      console.warn("client action play_animation requires a sprite/name field");
-    } else if (Number.isFinite(action.duration)) {
+    if (Number.isFinite(action.duration)) {
       playAnimationForDuration(spriteName, action.play_animation, action.duration);
     } else {
       playAnimation(spriteName, action.play_animation);
     }
   }
 
-  if (action.destroy_sprite) {
-    destroySprite(action.destroy_sprite);
-  }
-
-  if (action.disable_sprite) {
-    disableSprite(action.disable_sprite);
-  }
-
+  if (action.destroy_sprite) destroySprite(action.destroy_sprite);
   if (action.set_text && action.set_text.id !== undefined) {
-    setText(interpolateClientStateText(action.set_text.text || ""), action.set_text.id);
+    setText(action.set_text.text || "", action.set_text.id);
   }
-
-  if (action.show_text) {
-    showText(action.show_text);
-  }
-
-  if (action.hide_text) {
-    hideText(action.hide_text);
-  }
-
-  if (action.show_alert) {
-    showClientAlert(action.show_alert);
-  }
-
-  if (action.hide_when_state) {
-    const checks = Array.isArray(action.hide_when_state) ? action.hide_when_state : [action.hide_when_state];
-    checks.forEach((check) => {
-      if (stateConditionPasses(check)) hideText(check.id || check.name);
-    });
-  }
-
-  if (action.show_when_state) {
-    const checks = Array.isArray(action.show_when_state) ? action.show_when_state : [action.show_when_state];
-    checks.forEach((check) => {
-      if (stateConditionPasses(check)) showText(check.id || check.name);
-    });
-  }
-
-  if (action.destroy_when_state) {
-    const checks = Array.isArray(action.destroy_when_state) ? action.destroy_when_state : [action.destroy_when_state];
-    checks.forEach((check) => {
-      if (stateConditionPasses(check)) destroySprite(check.name || check.id);
-    });
-  }
-
-  if (action.disable_when_state) {
-    const checks = Array.isArray(action.disable_when_state) ? action.disable_when_state : [action.disable_when_state];
-    checks.forEach((check) => {
-      if (stateConditionPasses(check)) disableSprite(check.name || check.id);
-    });
-  }
-
-  return true;
+  if (action.show_text) showText(action.show_text);
+  if (action.hide_text) hideText(action.hide_text);
 }
 
-function showClientAlert(alertOptions) {
-  const options = typeof alertOptions === "string"
-    ? { title: alertOptions }
-    : alertOptions || {};
-
-  if (typeof swal === "function") {
-    swal(options);
-    return;
-  }
-
-  if (typeof sweetAlert === "function") {
-    sweetAlert(options);
-    return;
-  }
-
-  window.alert(options.title || options.text || "");
+function runBrowserActionList(actions) {
+  normalizeBrowserActions(actions).forEach(runBrowserAction);
 }
 
-function runClientActions(key) {
-  runClientActionList(key, GameBridge.keyControlActions[key]);
-}
-
-function runClientActionList(key, actions) {
-  for (const action of normalizeClientActions(actions)) {
-    const didRun = runClientAction(key, action);
-    if (didRun && action.stop_after_match) break;
-  }
-}
-
-function runClientActions(key) {
-  runClientActionList(key, GameBridge.keyControlActions[key]);
-}
-
-function addKeyControl(key, clientActions = []) {
-  GameBridge.keyControlActions[key] = clientActions;
-
-  if (GameBridge.keyControlHandlers[key]) {
-    return;
-  }
+function addKeyControl(key) {
+  if (GameBridge.keyControlHandlers[key]) return;
 
   const handler = function(e) {
-    const inputId = key + "_action";
-    if (key == e.code) {
-      runClientActions(key);
+    if (key === e.code) {
       Shiny.setInputValue(
-        inputId,
+        key + "_action",
         { code: e.code, evt_nonce: Date.now() + Math.random() },
         { priority: "event" }
       );
@@ -608,7 +267,7 @@ function addKeyControl(key, clientActions = []) {
   };
 
   GameBridge.keyControlHandlers[key] = handler;
-  document.addEventListener('keydown', handler);
+  document.addEventListener("keydown", handler);
 }
 
 function setSpriteInMotion(name, dirX, dirY, speed, distance) {

--- a/man/PhaserGame.Rd
+++ b/man/PhaserGame.Rd
@@ -422,7 +422,7 @@ Adds a collider between two game objects.
   group = NULL,
   action = NULL,
   input,
-  callback_fun = NULL
+  notify_server = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -438,7 +438,7 @@ Adds a collider between two game objects.
 \item{\code{action}}{R code containing supported shinyphaser R6 method calls,
 compiled for immediate browser execution when a collision occurs.}
 
-\item{\code{callback_fun}}{Deprecated server-side collision callback.}
+\item{\code{notify_server}}{Whether to also emit a Shiny input event.}
 
 \item{\code{input}}{Shiny input list.}
 }
@@ -457,7 +457,9 @@ Adds a collider between two game objects.
   group = NULL,
   action = NULL,
   input,
-  callback_fun = NULL
+  mode = c("enter", "stay"),
+  interval = 0,
+  notify_server = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -473,7 +475,11 @@ Adds a collider between two game objects.
 \item{\code{action}}{R code containing supported shinyphaser R6 method calls,
 compiled for immediate browser execution when an overlap occurs.}
 
-\item{\code{callback_fun}}{Optional function to be run on the Shiny server when overlap occurs.}
+\item{\code{mode}}{Whether actions run on overlap entry or remain active while overlapping.}
+
+\item{\code{interval}}{Minimum milliseconds between sustained actions.}
+
+\item{\code{notify_server}}{Whether to also emit a Shiny input event.}
 
 \item{\code{input}}{Shiny input list.}
 
@@ -515,7 +521,7 @@ Register a callback fired when overlap between objects ends.
   action = NULL,
   input,
   session = shiny::getDefaultReactiveDomain(),
-  callback_fun = NULL
+  notify_server = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -531,7 +537,7 @@ Register a callback fired when overlap between objects ends.
 \item{\code{action}}{R code containing supported shinyphaser R6 method calls,
 compiled for immediate browser execution when the overlap ends.}
 
-\item{\code{callback_fun}}{Optional function. Callback executed on the Shiny server when overlap ends.}
+\item{\code{notify_server}}{Whether to also emit a Shiny input event.}
 
 \item{\code{input}}{Shiny input list.}
 
@@ -550,7 +556,8 @@ Register a callback fired when a specific key is pressed.
 \if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_control(
   key,
   action = NULL,
-  input
+  input,
+  notify_server = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -560,7 +567,9 @@ Register a callback fired when a specific key is pressed.
 \item{\code{key}}{A character, accepts Javascript key events (they need to align with
 event.code).}
 
-\item{\code{action}}{Optional function to be run on the Shiny server after key is pressed.}
+\item{\code{action}}{R code compiled and run immediately in the browser.}
+
+\item{\code{notify_server}}{Whether to also emit a Shiny input event.}
 
 \item{\code{input}}{Shiny input list.}
 

--- a/man/PhaserGame.Rd
+++ b/man/PhaserGame.Rd
@@ -420,8 +420,9 @@ Adds a collider between two game objects.
   object_one,
   object_two = NULL,
   group = NULL,
-  callback_fun = NULL,
-  input
+  action = NULL,
+  input,
+  callback_fun = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -434,7 +435,10 @@ Adds a collider between two game objects.
 
 \item{\code{group}}{Character. Name of the group to compare against.}
 
-\item{\code{callback_fun}}{A function to be run when collision occurs.}
+\item{\code{action}}{R code containing supported shinyphaser R6 method calls,
+compiled for immediate browser execution when a collision occurs.}
+
+\item{\code{callback_fun}}{Deprecated server-side collision callback.}
 
 \item{\code{input}}{Shiny input list.}
 }
@@ -451,9 +455,9 @@ Adds a collider between two game objects.
   object_one,
   object_two = NULL,
   group = NULL,
-  callback_fun = NULL,
+  action = NULL,
   input,
-  client_action = NULL
+  callback_fun = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -466,12 +470,13 @@ Adds a collider between two game objects.
 
 \item{\code{group}}{Character. Name of the group.}
 
+\item{\code{action}}{R code containing supported shinyphaser R6 method calls,
+compiled for immediate browser execution when an overlap occurs.}
+
 \item{\code{callback_fun}}{Optional function to be run on the Shiny server when overlap occurs.}
 
 \item{\code{input}}{Shiny input list.}
 
-\item{\code{client_action}}{Optional list or list of lists describing immediate
-browser-side Phaser feedback to run when overlap occurs.}
 }
 \if{html}{\out{</div>}}
 }
@@ -507,10 +512,10 @@ Register a callback fired when overlap between objects ends.
   object_one,
   object_two = NULL,
   group = NULL,
-  callback_fun = NULL,
+  action = NULL,
   input,
   session = shiny::getDefaultReactiveDomain(),
-  client_action = NULL
+  callback_fun = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -523,14 +528,15 @@ Register a callback fired when overlap between objects ends.
 
 \item{\code{group}}{Character. Name of the group to compare against.}
 
+\item{\code{action}}{R code containing supported shinyphaser R6 method calls,
+compiled for immediate browser execution when the overlap ends.}
+
 \item{\code{callback_fun}}{Optional function. Callback executed on the Shiny server when overlap ends.}
 
 \item{\code{input}}{Shiny input list.}
 
 \item{\code{session}}{Shiny session object.}
 
-\item{\code{client_action}}{Optional list or list of lists describing immediate
-browser-side Phaser feedback to run when overlap ends.}
 }
 \if{html}{\out{</div>}}
 }
@@ -544,8 +550,7 @@ Register a callback fired when a specific key is pressed.
 \if{html}{\out{<div class="r">}}\preformatted{PhaserGame$add_control(
   key,
   action = NULL,
-  input,
-  client_action = NULL
+  input
 )}\if{html}{\out{</div>}}
 }
 
@@ -559,9 +564,6 @@ event.code).}
 
 \item{\code{input}}{Shiny input list.}
 
-\item{\code{client_action}}{Optional list or list of lists describing immediate
-browser-side Phaser feedback to run on keydown before Shiny receives the
-event.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -322,3 +322,13 @@ test_that("dungeonheroes Space action retains interactions and combat", {
   expect_true(any(grepl('title = "Game over"', example, fixed = TRUE)))
   expect_false(any(grepl("client_action", example, fixed = TRUE)))
 })
+
+test_that("browser feedback is configured for immediate visibility and audio", {
+  game_js <- readLines(system.file("www", "phaser-game.js", package = "shinyphaser"), warn = FALSE)
+  sprite_js <- readLines(system.file("www", "phaser-sprite.js", package = "shinyphaser"), warn = FALSE)
+
+  expect_true(any(grepl('context.state === "suspended"', game_js, fixed = TRUE)))
+  expect_true(any(grepl("context.resume().then", game_js, fixed = TRUE)))
+  expect_true(any(grepl("setDepth(10000)", sprite_js, fixed = TRUE)))
+  expect_true(any(grepl("alertText.setPosition(sprite.x", sprite_js, fixed = TRUE)))
+})

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -103,8 +103,8 @@ test_that("Sprite utility methods send expected JS", {
   expect_true(any(grepl("setGravity\\('hero', 1, 2\\);", msgs)))
   expect_true(any(grepl("setBounce\\('hero', 0.500000\\);", msgs)))
   expect_true(any(grepl("setSpriteInMotion\\('hero', 1, 0, 90, 45\\);", msgs)))
-  expect_true(any(grepl('setSpriteInMotionRandomOrToward\\("hero", "mushroom_man", 300.000000, 0.000000, 1.000000, 90.000000, 45.000000, 1.350000, 2.000000\\);', msgs)))
-  expect_true(any(grepl('startSpriteApproachOnSight\\("hero", "mushroom_man", 500.000000, 120.000000, 80.000000, 250.000000, 1200.000000\\);', msgs)))
+  expect_true(any(grepl('setSpriteInMotionRandomOrToward("hero", "mushroom_man", 300.000000', msgs, fixed = TRUE)))
+  expect_true(any(grepl('startSpriteApproachOnSight("hero", "mushroom_man", 500.000000, 120.000000, 80.000000, 250.000000, 1200.000000, 1500.000000);', msgs, fixed = TRUE)))
   expect_true(any(grepl("destroySprite\\('hero'\\);", msgs)))
 })
 
@@ -240,6 +240,40 @@ test_that("public handlers no longer expose client action lists", {
   expect_false("client_action" %in% names(formals(game$add_overlap)))
   expect_false("client_action" %in% names(formals(game$add_overlap_end)))
   expect_false("client_action" %in% names(formals(game$add_control)))
+  expect_false("callback_fun" %in% names(formals(game$add_collider)))
+  expect_false("callback_fun" %in% names(formals(game$add_overlap)))
+  expect_false("callback_fun" %in% names(formals(game$add_overlap_end)))
+})
+
+test_that("browser state, cooldowns, conditions, and semantic events compile", {
+  session <- make_mock_session()
+  game <- PhaserGame$new()
+  game$set_shiny_session(session)
+  hero <- game$add_sprite("hero", "hero.png", 0, 0, 32, 32, 1, 1)
+  sword <- game$add_static_sprite("sword", "sword.png", 10, 10)
+  has_sword <- game$add_state("has_sword", FALSE)
+  attack <- game$add_cooldown("attack", 750)
+
+  game$add_control("Space", action = {
+    if (hero$overlaps(sword) && sword$exists()) {
+      sword$destroy()
+      has_sword$set(TRUE)
+    } else if (attack$ready()) {
+      attack$trigger()
+      game$alert(title = "Attack")
+      game$emit("attack")
+    }
+  })
+
+  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
+  expect_true(any(grepl('setBrowserState("has_sword", false)', msgs, fixed = TRUE)))
+  control <- msgs[grepl('addKeyControl("Space"', msgs, fixed = TRUE)]
+  expect_length(control, 1)
+  expect_true(grepl('"op":"overlaps"', control, fixed = TRUE))
+  expect_true(grepl('"op":"cooldown_ready"', control, fixed = TRUE))
+  expect_true(grepl('"state_action":{"key":"has_sword","op":"set","value":true}', control, fixed = TRUE))
+  expect_true(grepl('"show_alert":{"title":"Attack"}', control, fixed = TRUE))
+  expect_true(grepl('"emit":{"name":"attack","data":[]}', control, fixed = TRUE))
 })
 
 test_that("action blocks reject unsupported R code instead of running it", {

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -334,4 +334,6 @@ test_that("browser feedback is configured for immediate visibility and audio", {
   expect_true(any(grepl("filecomplete-audio-${name}", game_js, fixed = TRUE)))
   expect_true(any(grepl("if (!scene.load.isLoading()) scene.load.start()", game_js, fixed = TRUE)))
   expect_true(any(grepl("() => addCollider(objectOneName", game_js, fixed = TRUE)))
+  expect_true(any(grepl("filecomplete-spritesheet-${name}", sprite_js, fixed = TRUE)))
+  expect_true(any(grepl("filecomplete-image-${name}", sprite_js, fixed = TRUE)))
 })

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -272,3 +272,17 @@ test_that("hedgehog action events retain game progress alerts", {
   expect_true(any(grepl('title = "You won!"', example, fixed = TRUE)))
   expect_false(any(grepl("callback_fun", example, fixed = TRUE)))
 })
+
+test_that("dungeonheroes Space action retains interactions and combat", {
+  example <- readLines(
+    system.file("examples", "dungeonheroes.R", package = "shinyphaser"),
+    warn = FALSE
+  )
+
+  expect_true(any(grepl("if (sword_in_range && !has_sword)", example, fixed = TRUE)))
+  expect_true(any(grepl('inventory_text$set("weapon: sword")', example, fixed = TRUE)))
+  expect_true(any(grepl("if (wizard_in_range)", example, fixed = TRUE)))
+  expect_true(any(grepl("enemy_hit_points[[enemy_in_range]]", example, fixed = TRUE)))
+  expect_true(any(grepl('title = "Game over"', example, fixed = TRUE)))
+  expect_false(any(grepl("client_action", example, fixed = TRUE)))
+})

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -194,6 +194,7 @@ test_that("PhaserGame action blocks compile R6 calls for immediate execution", {
   prompt <- game$add_text("Talk", "prompt", 0, 0, visible = FALSE)
   sound <- game$add_sound("hello", "hello.wav")
   hero <- game$add_sprite("hero", "hero.png", 0, 0, 32, 32, 1, 1)
+  apples <- game$add_static_group("apples", "apple.png")
   game$add_overlap(
     object_one = "hero",
     object_two = "wizard",
@@ -212,6 +213,13 @@ test_that("PhaserGame action blocks compile R6 calls for immediate execution", {
     action = prompt$hide()
   )
   game$add_collider("hero", "rock", input = input, action = sound$stop())
+  game$add_overlap(
+    "hero", group = "apples", input = input,
+    action = {
+      hero$set_in_motion(1, 0, 100, 50, lag = 0)
+      apples$disable()
+    }
+  )
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
   expect_true(any(grepl('addOverlap("hero", "wizard"', msgs, fixed = TRUE)))
@@ -222,6 +230,8 @@ test_that("PhaserGame action blocks compile R6 calls for immediate execution", {
   expect_true(any(grepl('"hide_text":"prompt"', msgs, fixed = TRUE)))
   expect_true(any(grepl('addCollider(\'hero\',\'rock\'', msgs, fixed = TRUE)))
   expect_true(any(grepl('"stop_sound":"hello"', msgs, fixed = TRUE)))
+  expect_true(any(grepl('"set_in_motion":{"name":"hero","dir_x":1,"dir_y":0,"speed":100,"distance":50}', msgs, fixed = TRUE)))
+  expect_true(any(grepl('"disable_overlap_member":"apples"', msgs, fixed = TRUE)))
 })
 
 test_that("public handlers no longer expose client action lists", {

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -331,4 +331,7 @@ test_that("browser feedback is configured for immediate visibility and audio", {
   expect_true(any(grepl("context.resume().then", game_js, fixed = TRUE)))
   expect_true(any(grepl("setDepth(10000)", sprite_js, fixed = TRUE)))
   expect_true(any(grepl("alertText.setPosition(sprite.x", sprite_js, fixed = TRUE)))
+  expect_true(any(grepl("filecomplete-audio-${name}", game_js, fixed = TRUE)))
+  expect_true(any(grepl("if (!scene.load.isLoading()) scene.load.start()", game_js, fixed = TRUE)))
+  expect_true(any(grepl("() => addCollider(objectOneName", game_js, fixed = TRUE)))
 })

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -260,3 +260,15 @@ test_that("action blocks reject unsupported R code instead of running it", {
   )
   expect_false(ran)
 })
+
+test_that("hedgehog action events retain game progress alerts", {
+  example <- readLines(
+    system.file("examples", "hedgehog.R", package = "shinyphaser"),
+    warn = FALSE
+  )
+
+  expect_true(any(grepl('title = "Game over"', example, fixed = TRUE)))
+  expect_true(any(grepl("passed_level_alert(level_id)", example, fixed = TRUE)))
+  expect_true(any(grepl('title = "You won!"', example, fixed = TRUE)))
+  expect_false(any(grepl("callback_fun", example, fixed = TRUE)))
+})

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -185,125 +185,68 @@ test_that("PhaserGame can create Sound objects", {
   expect_true(any(grepl("addSound\\(\\\"jump\\\", \\\"jump.wav\\\", 0.400000, true\\);", msgs)))
 })
 
-test_that("PhaserGame add_control supports immediate client actions", {
-  session <- make_mock_session()
-  game <- PhaserGame$new()
-  game$set_shiny_session(session)
-
-  input <- list(Space_action = NULL)
-  game$add_control(
-    "Space",
-    action = function() NULL,
-    input = input,
-    client_action = list(
-      play_sound = "hero_attack",
-      sprite = "hero",
-      play_animation = "hero_attack",
-      duration = 500,
-      cooldown = 750,
-      show_alert = list(title = "Hello", type = "info")
-    )
-  )
-
-  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
-  expect_true(any(grepl("addKeyControl\\(\"Space\",", msgs)))
-  expect_true(any(grepl('"play_sound":"hero_attack"', msgs, fixed = TRUE)))
-  expect_true(any(grepl('"play_animation":"hero_attack"', msgs, fixed = TRUE)))
-  expect_true(any(grepl('"cooldown":750', msgs, fixed = TRUE)))
-  expect_true(any(grepl('"show_alert":{"title":"Hello","type":"info"}', msgs, fixed = TRUE)))
-})
-
-test_that("PhaserGame client actions reject functions", {
-  session <- make_mock_session()
-  game <- PhaserGame$new()
-  game$set_shiny_session(session)
-
-  input <- list(Space_action = NULL)
-  expect_error(
-    game$add_control("Space", input = input, client_action = function(evt) NULL),
-    "client_action must be a list or list of lists",
-    fixed = TRUE
-  )
-})
-
-test_that("PhaserGame client actions support browser-side state changes", {
-  session <- make_mock_session()
-  game <- PhaserGame$new()
-  game$set_shiny_session(session)
-
-  input <- list(Space_action = NULL)
-  game$add_control(
-    "Space",
-    input = input,
-    client_action = list(
-      set_state = list(
-        list(key = "hero_life", op = "init", value = 100, min = 0, max = 100),
-        list(key = "hero_life", op = "decrement", amount = 10, min = 0, max = 100)
-      ),
-      set_text = list(id = "combat_status", text = "Life: {state.hero_life}/100"),
-      hide_when_state = list(id = "life_bar_green_10", key = "hero_life", op = "lte", value = 90),
-      disable_when_state = list(name = "mushroom_man_1", key = "enemy_life_mushroom_man_1", op = "lte", value = 0),
-      when_state = list(key = "hero_life", op = "gt", value = 0)
-    )
-  )
-
-  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
-  expect_true(any(grepl('"set_state":[{"key":"hero_life","op":"init"', msgs, fixed = TRUE)))
-  expect_true(any(grepl('"text":"Life: {state.hero_life}/100"', msgs, fixed = TRUE)))
-  expect_true(any(grepl('"hide_when_state":{"id":"life_bar_green_10"', msgs, fixed = TRUE)))
-  expect_true(any(grepl('"disable_when_state":{"name":"mushroom_man_1"', msgs, fixed = TRUE)))
-  expect_true(any(grepl('"when_state":{"key":"hero_life","op":"gt","value":0}', msgs, fixed = TRUE)))
-})
-
-test_that("PhaserGame client actions do not require server callbacks", {
+test_that("PhaserGame action blocks compile R6 calls for immediate execution", {
   session <- make_mock_session()
   game <- PhaserGame$new()
   game$set_shiny_session(session)
   input <- list()
 
-  game$add_control("KeyE", input = input, client_action = list(show_text = "prompt"))
+  prompt <- game$add_text("Talk", "prompt", 0, 0, visible = FALSE)
+  sound <- game$add_sound("hello", "hello.wav")
+  hero <- game$add_sprite("hero", "hero.png", 0, 0, 32, 32, 1, 1)
   game$add_overlap(
     object_one = "hero",
     object_two = "wizard",
     input = input,
-    client_action = list(show_text = "talk_bubble_text")
+    action = {
+      prompt$show()
+      sound$play(volume = 0.5)
+      hero$play_animation("wave", duration = 250)
+    }
   )
   game$add_overlap_end(
     object_one = "hero",
     object_two = "wizard",
     input = input,
     session = session,
-    client_action = list(hide_text = "talk_bubble_text")
+    action = prompt$hide()
   )
+  game$add_collider("hero", "rock", input = input, action = sound$stop())
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
-  expect_true(any(grepl('"show_text":"prompt"', msgs, fixed = TRUE)))
   expect_true(any(grepl('addOverlap("hero", "wizard"', msgs, fixed = TRUE)))
-  expect_true(any(grepl('"show_text":"talk_bubble_text"', msgs, fixed = TRUE)))
+  expect_true(any(grepl('"show_text":"prompt"', msgs, fixed = TRUE)))
+  expect_true(any(grepl('"play_sound":"hello","volume":0.5', msgs, fixed = TRUE)))
+  expect_true(any(grepl('"play_animation":"wave","sprite":"hero","duration":250', msgs, fixed = TRUE)))
   expect_true(any(grepl('addOverlapEnd("hero", "wizard"', msgs, fixed = TRUE)))
-  expect_true(any(grepl('"hide_text":"talk_bubble_text"', msgs, fixed = TRUE)))
+  expect_true(any(grepl('"hide_text":"prompt"', msgs, fixed = TRUE)))
+  expect_true(any(grepl('addCollider(\'hero\',\'rock\'', msgs, fixed = TRUE)))
+  expect_true(any(grepl('"stop_sound":"hello"', msgs, fixed = TRUE)))
 })
 
-test_that("overlap callbacks remain server-side callbacks", {
+test_that("public handlers no longer expose client action lists", {
+  game <- PhaserGame$new()
+
+  expect_false("client_action" %in% names(formals(game$add_overlap)))
+  expect_false("client_action" %in% names(formals(game$add_overlap_end)))
+  expect_false("client_action" %in% names(formals(game$add_control)))
+})
+
+test_that("action blocks reject unsupported R code instead of running it", {
   session <- make_mock_session()
   game <- PhaserGame$new()
   game$set_shiny_session(session)
 
   input <- list()
-  prompt <- game$add_text("...", "prompt", 0, 0, visible = FALSE)
-
-  game$add_overlap(
-    object_one = "hero",
-    object_two = "wizard",
-    callback_fun = function(evt) {
-      prompt$show()
-    },
-    input = input
+  ran <- FALSE
+  expect_error(
+    game$add_overlap(
+      object_one = "hero",
+      object_two = "wizard",
+      action = { ran <- TRUE },
+      input = input
+    ),
+    "action must contain calls"
   )
-
-  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
-  overlap_msg <- msgs[grepl('addOverlap("hero", "wizard"', msgs, fixed = TRUE)]
-  expect_length(overlap_msg, 1)
-  expect_false(grepl('"raw_js"', overlap_msg, fixed = TRUE))
-  expect_false(grepl('showText(\'prompt\');', overlap_msg, fixed = TRUE))
+  expect_false(ran)
 })

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -316,6 +316,8 @@ test_that("dungeonheroes Space action retains interactions and combat", {
   expect_true(any(grepl("if (sword_in_range && !has_sword)", example, fixed = TRUE)))
   expect_true(any(grepl('inventory_text$set("weapon: sword")', example, fixed = TRUE)))
   expect_true(any(grepl("if (wizard_in_range)", example, fixed = TRUE)))
+  expect_true(any(grepl("input$Space_action", example, fixed = TRUE)))
+  expect_true(any(grepl("notify_server = TRUE", example, fixed = TRUE)))
   expect_true(any(grepl("enemy_hit_points[[enemy_in_range]]", example, fixed = TRUE)))
   expect_true(any(grepl('title = "Game over"', example, fixed = TRUE)))
   expect_false(any(grepl("client_action", example, fixed = TRUE)))

--- a/vignettes/first-game.Rmd
+++ b/vignettes/first-game.Rmd
@@ -297,10 +297,9 @@ knitr::include_graphics("assets/first_game_5_move_animation.gif")
 ## 6) Add overlap with other objects (collect apples)
 
 Use overlap when two objects can share space and trigger events.
-In this step, apples act like collectibles: the hedgehog can move through them, and each touch fires a callback instead of blocking movement. We first create an `apples` static group and place a few apples on the map, then register `add_overlap()` between `"hedgehog"` and `"apples"`. Inside `callback_fun`, we hide the collected apple (`apples$disable(evt)`), increment score, and refresh on-screen text. In short: hedgehog meets apple, apple disappears, score goes up — because every hedgehog knows apples are the true quest objective.
+In this step, apples act like collectibles: the hedgehog can move through them, and each touch runs an immediate action instead of blocking movement. We first create an `apples` static group and place a few apples on the map, then register `add_overlap()` between `"hedgehog"` and `"apples"`. The immediate `action` block can hide the collected apple and update browser-resident state without waiting for Shiny. In short: hedgehog meets apple, apple disappears, score goes up — because every hedgehog knows apples are the true quest objective.
 
 ```{r eval=FALSE}
-score <- reactiveVal(0)
 apples <- game$add_static_group("apples", "assets/hedgehog/perks/apple_20.png")
 
 apples$create(260, 140)
@@ -308,14 +307,15 @@ apples$create(640, 180)
 apples$create(730, 390)
 
 score_text <- game$add_text(text = "Score: 0", id = "score", x = 20, y = 20)
+score <- game$add_state("score", 0)
 
 game$add_overlap(
   object_one = "hedgehog",
   group = "apples",
-  callback_fun = function(evt) {
-    apples$disable(evt)        # hide collected apple
-    score(score() + 1)
-    score_text$set(paste("Score:", score()))
+  action = {
+    apples$disable()
+    score$increment()
+    score_text$set(score$value())
   },
   input = input
 )
@@ -383,11 +383,6 @@ server <- function(input, output, session) {
   game$add_overlap(
     object_one = "hedgehog",
     group = "apples",
-    callback_fun = function(evt) {
-      apples$disable(evt)        # hide collected apple
-      score(score() + 1)
-      score_text$set(paste("Score:", score()))
-    },
     input = input
   )
 }
@@ -501,11 +496,6 @@ server <- function(input, output, session) {
   game$add_overlap(
     object_one = "hedgehog",
     group = "apples",
-    callback_fun = function(evt) {
-      apples$disable(evt)        # hide collected apple
-      score(score() + 1)
-      score_text$set(paste("Score:", score()))
-    },
     input = input
   )
 
@@ -542,13 +532,6 @@ enemy <- game$add_sprite(
 game$add_overlap(
   object_one = "hedgehog",
   object_two = "badger",
-  callback_fun = function(evt) {
-    shinyalert::shinyalert(
-      title = "Game over", type = "error",
-      closeOnClickOutside = FALSE, showCancelButton = FALSE,
-      callbackR = function(value) shiny::stopApp()
-    )
-  },
   input = input
 )
 
@@ -643,11 +626,6 @@ server <- function(input, output, session) {
   game$add_overlap(
     object_one = "hedgehog",
     group = "apples",
-    callback_fun = function(evt) {
-      apples$disable(evt)
-      score(score() + 1)
-      score_text$set(paste("Score:", score()))
-    },
     input = input
   )
 
@@ -670,13 +648,6 @@ server <- function(input, output, session) {
   game$add_overlap(
     object_one = "hedgehog",
     object_two = "badger",
-    callback_fun = function(evt) {
-      shinyalert::shinyalert(
-        title = "Game over", type = "error",
-        closeOnClickOutside = FALSE, showCancelButton = FALSE,
-        callbackR = function(value) shiny::stopApp()
-      )
-    },
     input = input
   )
 


### PR DESCRIPTION
### Motivation

- Provide a way to run immediate, browser-speed reactions for overlaps, collisions, and key controls without a Shiny round trip by replacing the ad-hoc `client_action` lists with compact R-style `action` blocks.
- Keep server-side callbacks available for work that cannot run in the browser while making common UI responses (show/hide text, play sounds/animations, destroy sprites, etc.) run instantly on the client.

### Description

- Added `action` parameters to `PhaserGame$add_overlap()`, `PhaserGame$add_overlap_end()`, `PhaserGame$add_collider()`, and removed public `client_action` parameters from the API signatures, while preserving `callback_fun` as the server callback option; these methods now `substitute()` the `action` expression and call `compile_phaser_action()` to produce a JSON-friendly action list sent to the client.
- Implemented `compile_phaser_action()` and `compile_phaser_action_call()` in `R/utils.R` to statically translate a small subset of R6 method calls into declarative browser actions, and updated constructors to pass a Shiny session into object factories (`add_sprite`, `add_group`, `add_static_sprite`, `add_static_group`).
- Reworked client JavaScript in `inst/www/phaser-game.js` and `inst/www/phaser-sprite.js` to consume the compiled browser actions via `runBrowserActionList()` / `runBrowserAction()` and removed the old `client_action` state machinery and many now-unused helpers, delegating only supported immediate operations (text show/hide/set, play/pause/stop sounds, play animations, destroy/disable sprites).
- Updated docs and examples (`README.Rmd`, `NEWS.md`, `inst/examples/dungeonheroes.R`, and man page `man/PhaserGame.Rd`) to show the new `action` usage and removed legacy client_action helpers and functions.

### Testing

- Ran the package test suite with `devtools::test()` (updated `tests/testthat/test-core-methods.R`) and confirmed the modified tests covering `action` compilation, JS message payloads, and public API signatures passed.
- Verified that core behavior assertions inspect sent JS snippets (via the mock session) and that expectations for `addOverlap`, `addOverlapEnd`, `addCollider`, and compiled action payloads existed in the captured messages and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69cfbcb880832fbe8ed5a92a2737b0)