### PR TITLE
Fix bear game keyboard movement and jumping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyphaser
 Title: An Interface to the 'Phaser.js' Game Framework
-Version: 0.1.0.9011
+Version: 0.1.0.9012
 Authors@R: 
     person(
       given = "Maciej", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * Queued sprite physics actions until sprites finish loading so setup calls such as `set_gravity()` are not lost during asynchronous asset initialization.
 
 ## New interface features
+* Added `gravity_x` and `gravity_y` parameters to `PhaserGame$new()` for configuring Arcade Physics world gravity when a game is created.
 * Added sound support with `PhaserGame$add_sound()` and a new `Sound` API for loading, playing, pausing, resuming, stopping, and configuring audio.
 * Added `set_scroll_factor()` helpers for scene objects so HUD-style elements can stay fixed while the camera follows another target.
 * Added camera follow helpers for sprites, images, rectangles, static sprites, and text scene objects so the Phaser camera can move with scene objects.

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -15,17 +15,23 @@ PhaserGame <- R6::R6Class(
     #' @param id Character. ID of the Game container (defaults to "phaser_game").
     #' @param width Numeric. Width of the Phaser canvas in pixels (defaults to 800).
     #' @param height Numeric. Height of the Phaser canvas in pixels (defaults to 600).
+    #' @param gravity_x Numeric. Horizontal Arcade Physics world gravity (defaults to 0).
+    #' @param gravity_y Numeric. Vertical Arcade Physics world gravity (defaults to 0).
     #' @return A new PhaserGame object.
     #' @examples
     #' game <- PhaserGame$new(id = "my_game", width = 1024, height = 768)
     initialize = function(id = "phaser_game",
                           width = 800,
-                          height = 600) {
+                          height = 600,
+                          gravity_x = 0,
+                          gravity_y = 0) {
       self$id <- id
 
       private$config <- list(
         width = width,
-        height = height
+        height = height,
+        gravity_x = gravity_x,
+        gravity_y = gravity_y
       )
     },
 

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -46,11 +46,7 @@ PhaserGame <- R6::R6Class(
         htmltools::tags$div(id = self$id, style = "width:100vw; height:100vh;"),
         htmltools::htmlDependency(
           name = "shinyphaser-assets",
-          # Use the package version as the asset cache key. A fixed dependency
-          # version made browsers keep serving old Phaser bridge scripts after
-          # package updates, so fixes appeared to have no effect until the
-          # browser cache was manually cleared.
-          version = as.character(utils::packageVersion("shinyphaser")),
+          version = "0.1",
           package = "shinyphaser",
           src = "www",
           script = c("phaser-game.js", "phaser-groups.js",

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -46,7 +46,11 @@ PhaserGame <- R6::R6Class(
         htmltools::tags$div(id = self$id, style = "width:100vw; height:100vh;"),
         htmltools::htmlDependency(
           name = "shinyphaser-assets",
-          version = "0.1",
+          # Use the package version as the asset cache key. A fixed dependency
+          # version made browsers keep serving old Phaser bridge scripts after
+          # package updates, so fixes appeared to have no effect until the
+          # browser cache was manually cleared.
+          version = as.character(utils::packageVersion("shinyphaser")),
           package = "shinyphaser",
           src = "www",
           script = c("phaser-game.js", "phaser-groups.js",

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -248,12 +248,12 @@ PhaserGame <- R6::R6Class(
       js <- if (!is.null(object_two)) {
         sprintf("addCollider('%s','%s',%s,%s)",
                 object_one, object_two,
-                jsonlite::toJSON(event_target, auto_unbox = TRUE),
+                phaser_event_target_json(event_target),
                 jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"))
       } else {
         sprintf("addGroupCollider('%s','%s',%s,%s)",
                 object_one, group,
-                jsonlite::toJSON(event_target, auto_unbox = TRUE),
+                phaser_event_target_json(event_target),
                 jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"))
       }
       send_js(private, js)
@@ -295,14 +295,14 @@ PhaserGame <- R6::R6Class(
         sprintf("addOverlap(%s, %s, %s, %s, %s, %s)",
                 jsonlite::toJSON(object_one, auto_unbox = TRUE),
                 jsonlite::toJSON(object_two, auto_unbox = TRUE),
-                jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
+                phaser_event_target_json(event_endpoint),
                 jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"),
                 jsonlite::toJSON(mode, auto_unbox = TRUE), interval)
       } else {
         sprintf("addGroupOverlap(%s, %s, %s, %s, %s, %s)",
                 jsonlite::toJSON(object_one, auto_unbox = TRUE),
                 jsonlite::toJSON(group, auto_unbox = TRUE),
-                jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
+                phaser_event_target_json(event_endpoint),
                 jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"),
                 jsonlite::toJSON(mode, auto_unbox = TRUE), interval)
       }
@@ -358,7 +358,7 @@ PhaserGame <- R6::R6Class(
      js <- sprintf("addOverlapEnd(%s, %s, %s, %s);",
                    jsonlite::toJSON(object_one, auto_unbox = TRUE),
                    jsonlite::toJSON(object_two, auto_unbox = TRUE),
-                   jsonlite::toJSON(event_endpoint, auto_unbox = TRUE),
+                   phaser_event_target_json(event_endpoint),
                    jsonlite::toJSON(browser_actions, auto_unbox = TRUE, null = "null"))
      session$sendCustomMessage("phaser", list(js = js))
    },

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,6 +2,11 @@ send_js <- function(private, js) {
   private$session$sendCustomMessage("phaser", list(js = js))
 }
 
+phaser_event_target_json <- function(target) {
+  if (is.null(target)) return("null")
+  jsonlite::toJSON(target, auto_unbox = TRUE)
+}
+
 # Translate a deliberately small, R-looking action block into the declarative
 # commands understood by the browser.  The expression is never evaluated: doing
 # so would send the R6 commands to Shiny, which is precisely the round trip this

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -74,11 +74,6 @@ server <- function(input, output, session) {
     },
     input
   )
-  bear$set_gravity(
-    x = 0,
-    y = 1200
-  )
-
   apples <- game$add_static_group(
     name = "apples",
     url = "assets/bear/perks/apple.png"
@@ -111,11 +106,6 @@ server <- function(input, output, session) {
     frame_width = 80,
     frame_height = 80
   )
-  wooden_box$set_gravity(
-    x = 0,
-    y = 500
-  )
-
   points_text <- game$add_text(
     text = "apples gathered: 0",
     id = "points_text",
@@ -133,6 +123,16 @@ server <- function(input, output, session) {
     object_one = "wooden_box",
     object_two = "grass",
     input = input
+  )
+  # Register the platform colliders before enabling gravity. The browser holds
+  # these gravity values until both objects in each collider are ready.
+  bear$set_gravity(
+    x = 0,
+    y = 1200
+  )
+  wooden_box$set_gravity(
+    x = 0,
+    y = 500
   )
   game$add_overlap(
     object_one = "bear",

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -74,6 +74,11 @@ server <- function(input, output, session) {
     },
     input
   )
+  bear$set_gravity(
+    x = 0,
+    y = 1200
+  )
+
   apples <- game$add_static_group(
     name = "apples",
     url = "assets/bear/perks/apple.png"
@@ -106,6 +111,11 @@ server <- function(input, output, session) {
     frame_width = 80,
     frame_height = 80
   )
+  wooden_box$set_gravity(
+    x = 0,
+    y = 500
+  )
+
   points_text <- game$add_text(
     text = "apples gathered: 0",
     id = "points_text",
@@ -123,16 +133,6 @@ server <- function(input, output, session) {
     object_one = "wooden_box",
     object_two = "grass",
     input = input
-  )
-  # Register the platform colliders before enabling gravity. The browser holds
-  # these gravity values until both objects in each collider are ready.
-  bear$set_gravity(
-    x = 0,
-    y = 1200
-  )
-  wooden_box$set_gravity(
-    x = 0,
-    y = 500
   )
   game$add_overlap(
     object_one = "bear",

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -26,23 +26,13 @@ server <- function(input, output, session) {
     y = 400
   )
 
-  # Load the platform before any gravity-enabled actors so their initial
-  # physics step cannot occur without the ground object being available.
-  grass <- game$add_static_sprite(
-    name = "grass",
-    url = "assets/bear/terrain/grass.png",
-    x = 800,
-    y = 755
-  )
-
   bear <- game$add_sprite(
     name = "bear",
     url = "assets/bear/player_sprites/bear_idle.png",
     x = 100,
-    y = 660,
+    y = 550,
     frame_width = 100,
     frame_height = 100,
-    frame_count = 10,
     frame_rate = 4
   )
   bear$add_animation(
@@ -50,7 +40,6 @@ server <- function(input, output, session) {
     url = "assets/bear/player_sprites/bear_move_right.png",
     frame_width = 100,
     frame_height = 100,
-    frame_count = 2,
     frame_rate = 6
   )
   bear$add_animation(
@@ -58,7 +47,6 @@ server <- function(input, output, session) {
     url = "assets/bear/player_sprites/bear_move_left.png",
     frame_width = 100,
     frame_height = 100,
-    frame_count = 2,
     frame_rate = 6
   )
   bear$add_animation(
@@ -66,7 +54,6 @@ server <- function(input, output, session) {
     url = "assets/bear/player_sprites/bear_jump.png",
     frame_width = 100,
     frame_height = 100,
-    frame_count = 2,
     frame_rate = 6
   )
   bear$add_player_controls(
@@ -79,21 +66,14 @@ server <- function(input, output, session) {
     "Space",
     action = {
       jump_sound$play()
+      bear$set_velocity_y(-600)
+      bear$play_animation(
+        anim_name = "bear_jump",
+        duration = 250
+      )
     },
-    input = input,
-    notify_server = TRUE
+    input
   )
-
-  shiny::observeEvent(input$Space_action, {
-    # Keep physics mutations in the Shiny observer. This uses the same
-    # established command path as the rest of the Sprite API rather than
-    # depending on action-block compilation for the platforming controls.
-    bear$set_velocity_y(-600)
-    bear$play_animation(
-      anim_name = "bear_jump",
-      duration = 250
-    )
-  })
   bear$set_gravity(
     x = 0,
     y = 1200
@@ -116,11 +96,18 @@ server <- function(input, output, session) {
     y = 600
   )
 
+  grass <- game$add_static_sprite(
+    name = "grass",
+    url = "assets/bear/terrain/grass.png",
+    x = 800,
+    y = 755
+  )
+
   wooden_box <- game$add_sprite(
     name = "wooden_box",
     url = "assets/bear/obstacles/wooden_box.png",
     x = 300,
-    y = 670,
+    y = 600,
     frame_width = 80,
     frame_height = 80
   )

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -1,6 +1,6 @@
 devtools::load_all()
 
-game <- PhaserGame$new(width = 800, height = 800)
+game <- PhaserGame$new(width = 800, height = 800, gravity_y = 1200)
 
 ui <- shiny::tagList(
   game$use_phaser()
@@ -74,11 +74,6 @@ server <- function(input, output, session) {
     },
     input
   )
-  bear$set_gravity(
-    x = 0,
-    y = 1200
-  )
-
   apples <- game$add_static_group(
     name = "apples",
     url = "assets/bear/perks/apple.png"
@@ -111,11 +106,6 @@ server <- function(input, output, session) {
     frame_width = 80,
     frame_height = 80
   )
-  wooden_box$set_gravity(
-    x = 0,
-    y = 500
-  )
-
   points_text <- game$add_text(
     text = "apples gathered: 0",
     id = "points_text",

--- a/inst/examples/bear.R
+++ b/inst/examples/bear.R
@@ -26,13 +26,23 @@ server <- function(input, output, session) {
     y = 400
   )
 
+  # Load the platform before any gravity-enabled actors so their initial
+  # physics step cannot occur without the ground object being available.
+  grass <- game$add_static_sprite(
+    name = "grass",
+    url = "assets/bear/terrain/grass.png",
+    x = 800,
+    y = 755
+  )
+
   bear <- game$add_sprite(
     name = "bear",
     url = "assets/bear/player_sprites/bear_idle.png",
     x = 100,
-    y = 550,
+    y = 660,
     frame_width = 100,
     frame_height = 100,
+    frame_count = 10,
     frame_rate = 4
   )
   bear$add_animation(
@@ -40,6 +50,7 @@ server <- function(input, output, session) {
     url = "assets/bear/player_sprites/bear_move_right.png",
     frame_width = 100,
     frame_height = 100,
+    frame_count = 2,
     frame_rate = 6
   )
   bear$add_animation(
@@ -47,6 +58,7 @@ server <- function(input, output, session) {
     url = "assets/bear/player_sprites/bear_move_left.png",
     frame_width = 100,
     frame_height = 100,
+    frame_count = 2,
     frame_rate = 6
   )
   bear$add_animation(
@@ -54,6 +66,7 @@ server <- function(input, output, session) {
     url = "assets/bear/player_sprites/bear_jump.png",
     frame_width = 100,
     frame_height = 100,
+    frame_count = 2,
     frame_rate = 6
   )
   bear$add_player_controls(
@@ -66,14 +79,21 @@ server <- function(input, output, session) {
     "Space",
     action = {
       jump_sound$play()
-      bear$set_velocity_y(-600)
-      bear$play_animation(
-        anim_name = "bear_jump",
-        duration = 250
-      )
     },
-    input
+    input = input,
+    notify_server = TRUE
   )
+
+  shiny::observeEvent(input$Space_action, {
+    # Keep physics mutations in the Shiny observer. This uses the same
+    # established command path as the rest of the Sprite API rather than
+    # depending on action-block compilation for the platforming controls.
+    bear$set_velocity_y(-600)
+    bear$play_animation(
+      anim_name = "bear_jump",
+      duration = 250
+    )
+  })
   bear$set_gravity(
     x = 0,
     y = 1200
@@ -96,18 +116,11 @@ server <- function(input, output, session) {
     y = 600
   )
 
-  grass <- game$add_static_sprite(
-    name = "grass",
-    url = "assets/bear/terrain/grass.png",
-    x = 800,
-    y = 755
-  )
-
   wooden_box <- game$add_sprite(
     name = "wooden_box",
     url = "assets/bear/obstacles/wooden_box.png",
     x = 300,
-    y = 600,
+    y = 670,
     frame_width = 80,
     frame_height = 80
   )

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -9,8 +9,6 @@ GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
 GameBridge.pendingScrollFactor = GameBridge.pendingScrollFactor || {};
 GameBridge.pendingWorldBounds = GameBridge.pendingWorldBounds || null;
 GameBridge.pendingTerrainColliders = GameBridge.pendingTerrainColliders || [];
-GameBridge.pendingColliderNames = GameBridge.pendingColliderNames || new Set();
-GameBridge.frozenColliderBodies = GameBridge.frozenColliderBodies || new Map();
 GameBridge.lastHeroOverlapState = GameBridge.lastHeroOverlapState || "";
 GameBridge.nextHeroOverlapSendAt = GameBridge.nextHeroOverlapSendAt || 0;
 GameBridge.sounds = GameBridge.sounds || {};
@@ -62,30 +60,12 @@ function playTypeAnim(sprite, type, suffix) {
 
 function initPhaserGame(containerId, config) {
   GameBridge.overlapEndWatchers = {};
-  GameBridge.playerControls = {};
-  GameBridge.forcedAnimations = {};
-  GameBridge.pendingColliderNames = new Set();
-  GameBridge.frozenColliderBodies = new Map();
-
-  // A Shiny reconnect can initialize a new Phaser scene without reloading the
-  // page. Remove controls which still point at the previous scene before the
-  // new game registers its own controls.
-  Object.values(GameBridge.keyControlHandlers || {}).forEach((handler) => {
-    document.removeEventListener("keydown", handler);
-  });
-  GameBridge.keyControlHandlers = {};
 
   window.game = new Phaser.Game({
     type: Phaser.AUTO,
     width: config.width,
     height: config.height,
     parent: containerId,
-    // Shiny commonly runs games inside RStudio's Viewer pane or another
-    // iframe. Phaser pauses its entire game loop on a visibility/focus change
-    // by default, even though DOM key handlers can continue to receive input.
-    // That leaves sounds working while physics, movement, and jumps appear
-    // frozen. Keep the loop alive in embedded views.
-    disableVisibilityChange: true,
     physics: { default: 'arcade' },
     scene: {
       preload: preload,
@@ -118,7 +98,7 @@ function initPhaserGame(containerId, config) {
 
       Object.entries(GameBridge.playerControls).forEach(([name, opts]) => {
           const sprite = this.children.getByName(name);
-          if (!sprite || !sprite.active || !sprite.body || !sprite.body.enable) return;
+          if (!sprite) return;
 
           const { speed, directionMap } = opts;
 
@@ -274,14 +254,6 @@ function addPlayerControls(name, directions, speed) {
       down: directions.includes("down")
     }
   };
-
-  // Cursor keys otherwise retain the browser's default scrolling behavior in
-  // some embedding contexts, which can move focus away from the game canvas.
-  if (scene && scene.input && scene.input.keyboard) {
-    scene.input.keyboard.addCapture(
-      directions.map((direction) => direction.toUpperCase())
-    );
-  }
 };
 
 function applyWorldBounds(bounds) {
@@ -399,8 +371,7 @@ function addPlayerTerrainCollider(spriteName) {
 function addCollider(objectOneName, objectTwoName, inputId, browserActions = []) {
   if (retryWhenMissingObjects(
     () => addCollider(objectOneName, objectTwoName, inputId, browserActions),
-    [objectOneName, objectTwoName],
-    true
+    [objectOneName, objectTwoName]
   )) return;
   const objectOne = scene.children.getByName(objectOneName);
   const objectTwo = scene.children.getByName(objectTwoName);
@@ -411,7 +382,6 @@ function addCollider(objectOneName, objectTwoName, inputId, browserActions = [])
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );
-  releasePendingColliderBodies([objectOneName, objectTwoName]);
 }
 
 function addGroupCollider(objectName, groupName, inputId, browserActions = []) {
@@ -430,41 +400,12 @@ function addGroupCollider(objectName, groupName, inputId, browserActions = []) {
   );
 }
 
-function retryWhenMissingObjects(fn, objectNames, freezeBodies = false) {
+function retryWhenMissingObjects(fn, objectNames) {
   const missingObject = objectNames.some((name) => !scene.children.getByName(name));
   if (!missingObject) return false;
 
-  // Objects loaded at runtime start participating in Arcade Physics as soon as
-  // their individual texture finishes. A falling object can therefore pass
-  // through a platform whose texture is still loading before the collider is
-  // registered. Freeze dynamic participants until all collider objects exist.
-  if (freezeBodies) {
-    objectNames.forEach((name) => {
-      GameBridge.pendingColliderNames.add(name);
-      freezePendingColliderBody(name);
-    });
-  }
   window.setTimeout(fn, 100);
   return true;
-}
-
-function freezePendingColliderBody(name) {
-  if (!GameBridge.pendingColliderNames.has(name) || !scene) return;
-  const object = scene.children.getByName(name);
-  const body = object && object.body;
-  if (!body || !body.moves || GameBridge.frozenColliderBodies.has(name)) return;
-
-  GameBridge.frozenColliderBodies.set(name, body);
-  body.moves = false;
-}
-
-function releasePendingColliderBodies(objectNames) {
-  objectNames.forEach((name) => {
-    GameBridge.pendingColliderNames.delete(name);
-    const body = GameBridge.frozenColliderBodies.get(name);
-    if (body) body.moves = true;
-    GameBridge.frozenColliderBodies.delete(name);
-  });
 }
 
 function addOverlap(objectOneName, objectTwoName, inputId, browserActions = [], mode = "enter", interval = 0) {

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -66,7 +66,15 @@ function initPhaserGame(containerId, config) {
     width: config.width,
     height: config.height,
     parent: containerId,
-    physics: { default: 'arcade' },
+    physics: {
+      default: 'arcade',
+      arcade: {
+        gravity: {
+          x: Number(config.gravity_x) || 0,
+          y: Number(config.gravity_y) || 0
+        }
+      }
+    },
     scene: {
       preload: preload,
       create: create,
@@ -375,17 +383,12 @@ function addCollider(objectOneName, objectTwoName, inputId, browserActions = [])
   )) return;
   const objectOne = scene.children.getByName(objectOneName);
   const objectTwo = scene.children.getByName(objectTwoName);
-  const hasBrowserActions = Array.isArray(browserActions)
-    ? browserActions.length > 0
-    : Boolean(browserActions && Object.keys(browserActions).length);
-  const collisionCallback = (inputId || hasBrowserActions)
-    ? function(obj1, obj2) {
-        runBrowserActionList(browserActions, obj1, obj2);
-        sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
-      }
-    : null;
   scene.physics.add.collider(
-    objectOne, objectTwo, collisionCallback
+    objectOne, objectTwo,
+    function(obj1, obj2) {
+      runBrowserActionList(browserActions, obj1, obj2);
+      sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
+    }
   );
 }
 

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -60,6 +60,16 @@ function playTypeAnim(sprite, type, suffix) {
 
 function initPhaserGame(containerId, config) {
   GameBridge.overlapEndWatchers = {};
+  GameBridge.playerControls = {};
+  GameBridge.forcedAnimations = {};
+
+  // A Shiny reconnect can initialize a new Phaser scene without reloading the
+  // page. Remove controls which still point at the previous scene before the
+  // new game registers its own controls.
+  Object.values(GameBridge.keyControlHandlers || {}).forEach((handler) => {
+    document.removeEventListener("keydown", handler);
+  });
+  GameBridge.keyControlHandlers = {};
 
   window.game = new Phaser.Game({
     type: Phaser.AUTO,
@@ -98,7 +108,7 @@ function initPhaserGame(containerId, config) {
 
       Object.entries(GameBridge.playerControls).forEach(([name, opts]) => {
           const sprite = this.children.getByName(name);
-          if (!sprite) return;
+          if (!sprite || !sprite.active || !sprite.body || !sprite.body.enable) return;
 
           const { speed, directionMap } = opts;
 
@@ -254,6 +264,14 @@ function addPlayerControls(name, directions, speed) {
       down: directions.includes("down")
     }
   };
+
+  // Cursor keys otherwise retain the browser's default scrolling behavior in
+  // some embedding contexts, which can move focus away from the game canvas.
+  if (scene && scene.input && scene.input.keyboard) {
+    scene.input.keyboard.addCapture(
+      directions.map((direction) => direction.toUpperCase())
+    );
+  }
 };
 
 function applyWorldBounds(bounds) {

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -76,6 +76,12 @@ function initPhaserGame(containerId, config) {
     width: config.width,
     height: config.height,
     parent: containerId,
+    // Shiny commonly runs games inside RStudio's Viewer pane or another
+    // iframe. Phaser pauses its entire game loop on a visibility/focus change
+    // by default, even though DOM key handlers can continue to receive input.
+    // That leaves sounds working while physics, movement, and jumps appear
+    // frozen. Keep the loop alive in embedded views.
+    disableVisibilityChange: true,
     physics: { default: 'arcade' },
     scene: {
       preload: preload,

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -15,8 +15,12 @@ GameBridge.sounds = GameBridge.sounds || {};
 GameBridge.pendingSoundActions = GameBridge.pendingSoundActions || {};
 
 function sendPhaserEvent(target, payload) {
-  if (!target) return;
-  if (typeof target === "string" && (/^https?:/.test(target) || target.includes("/")) && window.fetch) {
+  // jsonlite represented an absent R event target as an empty object in older
+  // messages. Shiny input names must be strings; passing that object reaches
+  // Shiny's input-name splitter and throws `e.split is not a function`, which
+  // aborts Phaser's game loop on the first collision.
+  if (typeof target !== "string" || target.length === 0) return;
+  if ((/^https?:/.test(target) || target.includes("/")) && window.fetch) {
     window.fetch(target, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -9,6 +9,8 @@ GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
 GameBridge.pendingScrollFactor = GameBridge.pendingScrollFactor || {};
 GameBridge.pendingWorldBounds = GameBridge.pendingWorldBounds || null;
 GameBridge.pendingTerrainColliders = GameBridge.pendingTerrainColliders || [];
+GameBridge.pendingColliderNames = GameBridge.pendingColliderNames || new Set();
+GameBridge.frozenColliderBodies = GameBridge.frozenColliderBodies || new Map();
 GameBridge.lastHeroOverlapState = GameBridge.lastHeroOverlapState || "";
 GameBridge.nextHeroOverlapSendAt = GameBridge.nextHeroOverlapSendAt || 0;
 GameBridge.sounds = GameBridge.sounds || {};
@@ -62,6 +64,8 @@ function initPhaserGame(containerId, config) {
   GameBridge.overlapEndWatchers = {};
   GameBridge.playerControls = {};
   GameBridge.forcedAnimations = {};
+  GameBridge.pendingColliderNames = new Set();
+  GameBridge.frozenColliderBodies = new Map();
 
   // A Shiny reconnect can initialize a new Phaser scene without reloading the
   // page. Remove controls which still point at the previous scene before the
@@ -395,7 +399,8 @@ function addPlayerTerrainCollider(spriteName) {
 function addCollider(objectOneName, objectTwoName, inputId, browserActions = []) {
   if (retryWhenMissingObjects(
     () => addCollider(objectOneName, objectTwoName, inputId, browserActions),
-    [objectOneName, objectTwoName]
+    [objectOneName, objectTwoName],
+    true
   )) return;
   const objectOne = scene.children.getByName(objectOneName);
   const objectTwo = scene.children.getByName(objectTwoName);
@@ -406,6 +411,7 @@ function addCollider(objectOneName, objectTwoName, inputId, browserActions = [])
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );
+  releasePendingColliderBodies([objectOneName, objectTwoName]);
 }
 
 function addGroupCollider(objectName, groupName, inputId, browserActions = []) {
@@ -424,12 +430,41 @@ function addGroupCollider(objectName, groupName, inputId, browserActions = []) {
   );
 }
 
-function retryWhenMissingObjects(fn, objectNames) {
+function retryWhenMissingObjects(fn, objectNames, freezeBodies = false) {
   const missingObject = objectNames.some((name) => !scene.children.getByName(name));
   if (!missingObject) return false;
 
+  // Objects loaded at runtime start participating in Arcade Physics as soon as
+  // their individual texture finishes. A falling object can therefore pass
+  // through a platform whose texture is still loading before the collider is
+  // registered. Freeze dynamic participants until all collider objects exist.
+  if (freezeBodies) {
+    objectNames.forEach((name) => {
+      GameBridge.pendingColliderNames.add(name);
+      freezePendingColliderBody(name);
+    });
+  }
   window.setTimeout(fn, 100);
   return true;
+}
+
+function freezePendingColliderBody(name) {
+  if (!GameBridge.pendingColliderNames.has(name) || !scene) return;
+  const object = scene.children.getByName(name);
+  const body = object && object.body;
+  if (!body || !body.moves || GameBridge.frozenColliderBodies.has(name)) return;
+
+  GameBridge.frozenColliderBodies.set(name, body);
+  body.moves = false;
+}
+
+function releasePendingColliderBodies(objectNames) {
+  objectNames.forEach((name) => {
+    GameBridge.pendingColliderNames.delete(name);
+    const body = GameBridge.frozenColliderBodies.get(name);
+    if (body) body.moves = true;
+    GameBridge.frozenColliderBodies.delete(name);
+  });
 }
 
 function addOverlap(objectOneName, objectTwoName, inputId, browserActions = [], mode = "enter", interval = 0) {

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -9,6 +9,8 @@ GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
 GameBridge.pendingScrollFactor = GameBridge.pendingScrollFactor || {};
 GameBridge.pendingWorldBounds = GameBridge.pendingWorldBounds || null;
 GameBridge.pendingTerrainColliders = GameBridge.pendingTerrainColliders || [];
+GameBridge.pendingObjectColliders = GameBridge.pendingObjectColliders || [];
+GameBridge.pendingGravity = GameBridge.pendingGravity || {};
 GameBridge.lastHeroOverlapState = GameBridge.lastHeroOverlapState || "";
 GameBridge.nextHeroOverlapSendAt = GameBridge.nextHeroOverlapSendAt || 0;
 GameBridge.sounds = GameBridge.sounds || {};
@@ -60,6 +62,8 @@ function playTypeAnim(sprite, type, suffix) {
 
 function initPhaserGame(containerId, config) {
   GameBridge.overlapEndWatchers = {};
+  GameBridge.pendingObjectColliders = [];
+  GameBridge.pendingGravity = {};
 
   window.game = new Phaser.Game({
     type: Phaser.AUTO,
@@ -369,12 +373,21 @@ function addPlayerTerrainCollider(spriteName) {
 }
 
 function addCollider(objectOneName, objectTwoName, inputId, browserActions = []) {
-  if (retryWhenMissingObjects(
-    () => addCollider(objectOneName, objectTwoName, inputId, browserActions),
-    [objectOneName, objectTwoName]
-  )) return;
+  const pending = { objectOneName, objectTwoName, inputId, browserActions };
+  if (!addObjectColliderWhenReady(pending)) {
+    GameBridge.pendingObjectColliders.push(pending);
+  } else {
+    applyPendingGravity(objectOneName);
+    applyPendingGravity(objectTwoName);
+  }
+}
+
+function addObjectColliderWhenReady(pending) {
+  const { objectOneName, objectTwoName, inputId, browserActions } = pending;
   const objectOne = scene.children.getByName(objectOneName);
   const objectTwo = scene.children.getByName(objectTwoName);
+  if (!objectOne || !objectTwo) return false;
+
   scene.physics.add.collider(
     objectOne, objectTwo,
     function(obj1, obj2) {
@@ -382,6 +395,32 @@ function addCollider(objectOneName, objectTwoName, inputId, browserActions = [])
       sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
     }
   );
+  return true;
+}
+
+function applyPendingObjectColliders() {
+  const completedNames = [];
+  GameBridge.pendingObjectColliders = GameBridge.pendingObjectColliders.filter(
+    (pending) => {
+      if (!addObjectColliderWhenReady(pending)) return true;
+      completedNames.push(pending.objectOneName, pending.objectTwoName);
+      return false;
+    }
+  );
+  completedNames.forEach(applyPendingGravity);
+}
+
+function hasPendingObjectCollider(name) {
+  return GameBridge.pendingObjectColliders.some((pending) =>
+    pending.objectOneName === name || pending.objectTwoName === name
+  );
+}
+
+function applyPendingGravity(name) {
+  const gravity = GameBridge.pendingGravity[name];
+  if (!gravity || hasPendingObjectCollider(name)) return;
+  delete GameBridge.pendingGravity[name];
+  setGravity(name, gravity.x, gravity.y);
 }
 
 function addGroupCollider(objectName, groupName, inputId, browserActions = []) {

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -9,8 +9,6 @@ GameBridge.pendingCameraFollow = GameBridge.pendingCameraFollow || {};
 GameBridge.pendingScrollFactor = GameBridge.pendingScrollFactor || {};
 GameBridge.pendingWorldBounds = GameBridge.pendingWorldBounds || null;
 GameBridge.pendingTerrainColliders = GameBridge.pendingTerrainColliders || [];
-GameBridge.pendingObjectColliders = GameBridge.pendingObjectColliders || [];
-GameBridge.pendingGravity = GameBridge.pendingGravity || {};
 GameBridge.lastHeroOverlapState = GameBridge.lastHeroOverlapState || "";
 GameBridge.nextHeroOverlapSendAt = GameBridge.nextHeroOverlapSendAt || 0;
 GameBridge.sounds = GameBridge.sounds || {};
@@ -62,8 +60,6 @@ function playTypeAnim(sprite, type, suffix) {
 
 function initPhaserGame(containerId, config) {
   GameBridge.overlapEndWatchers = {};
-  GameBridge.pendingObjectColliders = [];
-  GameBridge.pendingGravity = {};
 
   window.game = new Phaser.Game({
     type: Phaser.AUTO,
@@ -373,54 +369,24 @@ function addPlayerTerrainCollider(spriteName) {
 }
 
 function addCollider(objectOneName, objectTwoName, inputId, browserActions = []) {
-  const pending = { objectOneName, objectTwoName, inputId, browserActions };
-  if (!addObjectColliderWhenReady(pending)) {
-    GameBridge.pendingObjectColliders.push(pending);
-  } else {
-    applyPendingGravity(objectOneName);
-    applyPendingGravity(objectTwoName);
-  }
-}
-
-function addObjectColliderWhenReady(pending) {
-  const { objectOneName, objectTwoName, inputId, browserActions } = pending;
+  if (retryWhenMissingObjects(
+    () => addCollider(objectOneName, objectTwoName, inputId, browserActions),
+    [objectOneName, objectTwoName]
+  )) return;
   const objectOne = scene.children.getByName(objectOneName);
   const objectTwo = scene.children.getByName(objectTwoName);
-  if (!objectOne || !objectTwo) return false;
-
+  const hasBrowserActions = Array.isArray(browserActions)
+    ? browserActions.length > 0
+    : Boolean(browserActions && Object.keys(browserActions).length);
+  const collisionCallback = (inputId || hasBrowserActions)
+    ? function(obj1, obj2) {
+        runBrowserActionList(browserActions, obj1, obj2);
+        sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
+      }
+    : null;
   scene.physics.add.collider(
-    objectOne, objectTwo,
-    function(obj1, obj2) {
-      runBrowserActionList(browserActions, obj1, obj2);
-      sendPhaserEvent(inputId, phaserCollisionPayload(obj1, obj2));
-    }
+    objectOne, objectTwo, collisionCallback
   );
-  return true;
-}
-
-function applyPendingObjectColliders() {
-  const completedNames = [];
-  GameBridge.pendingObjectColliders = GameBridge.pendingObjectColliders.filter(
-    (pending) => {
-      if (!addObjectColliderWhenReady(pending)) return true;
-      completedNames.push(pending.objectOneName, pending.objectTwoName);
-      return false;
-    }
-  );
-  completedNames.forEach(applyPendingGravity);
-}
-
-function hasPendingObjectCollider(name) {
-  return GameBridge.pendingObjectColliders.some((pending) =>
-    pending.objectOneName === name || pending.objectTwoName === name
-  );
-}
-
-function applyPendingGravity(name) {
-  const gravity = GameBridge.pendingGravity[name];
-  if (!gravity || hasPendingObjectCollider(name)) return;
-  delete GameBridge.pendingGravity[name];
-  setGravity(name, gravity.x, gravity.y);
 }
 
 function addGroupCollider(objectName, groupName, inputId, browserActions = []) {

--- a/inst/www/phaser-groups.js
+++ b/inst/www/phaser-groups.js
@@ -1,6 +1,3 @@
-window.GameBridge = window.GameBridge || {};
-GameBridge.pendingGroupMembers = GameBridge.pendingGroupMembers || {};
-
 function addGroup(name) {
   if (!scene[name]) {
     scene[name] = scene.physics.add.group();
@@ -12,7 +9,7 @@ function addGroupAnimation(groupName, suffix, url, w, h, totalFrames, rate) {
     frameWidth: w, frameHeight: h, endFrame: totalFrames - 1
   });
 
-  scene.load.once(`filecomplete-spritesheet-${groupName}`, () => {
+  scene.load.once('complete', () => {
     scene.anims.create({
       key: `${groupName}_${suffix}`,
       frames: scene.anims.generateFrameNumbers(groupName, { start: 0, end: totalFrames - 1 }),
@@ -20,15 +17,10 @@ function addGroupAnimation(groupName, suffix, url, w, h, totalFrames, rate) {
       repeat: -1
     });
   });
-  if (!scene.load.isLoading()) scene.load.start();
+  scene.load.start();
 }
 
 function addToGroup(groupName, x, y) {
-  if (!scene.textures.exists(groupName)) {
-    GameBridge.pendingGroupMembers[groupName] = GameBridge.pendingGroupMembers[groupName] || [];
-    GameBridge.pendingGroupMembers[groupName].push({ x, y });
-    return;
-  }
   const sprite = scene[groupName].create(x, y, groupName);
   playTypeAnim(sprite, groupName, "idle");
 }
@@ -38,12 +30,9 @@ function addStaticGroup(name, url) {
     scene[name] = scene.physics.add.staticGroup();
   }
   scene.load.image(name, url);
-  scene.load.once(`filecomplete-image-${name}`, () => {
-    const pending = GameBridge.pendingGroupMembers[name] || [];
-    pending.forEach(({ x, y }) => addToGroup(name, x, y));
-    delete GameBridge.pendingGroupMembers[name];
+  scene.load.once('complete', () => {
   });
-  if (!scene.load.isLoading()) scene.load.start();
+  scene.load.start();
 }
 
 function disableBody(groupName, x, y) {

--- a/inst/www/phaser-image.js
+++ b/inst/www/phaser-image.js
@@ -1,7 +1,7 @@
 function addImage(imageName, imageUrl, x = null, y = null, visible = true, clickable = true) {
   scene.load.image(imageName, imageUrl);
 
-  scene.load.once(`filecomplete-image-${imageName}`, () => {
+  scene.load.once('complete', () => {
     const px = x !== null
       ? x
       : scene.cameras.main.width  / 2;
@@ -23,7 +23,7 @@ function addImage(imageName, imageUrl, x = null, y = null, visible = true, click
     }
   });
 
-  if (!scene.load.isLoading()) scene.load.start();
+  scene.load.start();
 }
 
 function showImage(imageName) {

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -181,11 +181,7 @@ function playAnimationForDuration(name, animName, duration) {
 
 function setGravity(name, x, y) {
   withSprite(name, (sprite) => {
-    if (typeof sprite.setGravity === "function") {
-      sprite.setGravity(x, y);
-    } else if (sprite.body && typeof sprite.body.setGravity === "function") {
-      sprite.body.setGravity(x, y);
-    }
+    if (sprite.body) sprite.body.setGravity(x, y);
   }, "setGravity()");
 }
 

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -73,9 +73,6 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
     sprite.play(name + '_idle');
 
     scene[name] = sprite;
-    if (typeof freezePendingColliderBody === "function") {
-      freezePendingColliderBody(name);
-    }
     applyPendingSpriteActions(name);
 
     if (typeof applyPendingCameraFollows === "function") {
@@ -100,9 +97,6 @@ function addStaticSprite(name, url, x, y) {
       scene.physics.add.collider(staticSprite, scene.terrainLayer);
     }
     scene[name] = staticSprite;
-    if (typeof freezePendingColliderBody === "function") {
-      freezePendingColliderBody(name);
-    }
 
     if (typeof applyPendingCameraFollows === "function") {
       applyPendingCameraFollows();
@@ -192,15 +186,13 @@ function setGravity(name, x, y) {
 }
 
 function setVelocityX(name, x) {
-  withSprite(name, (sprite) => {
-    if (sprite.body && sprite.body.enable) sprite.body.setVelocityX(x);
-  }, "setVelocityX()");
+  const sprite = scene[name];
+  sprite.body.setVelocityX(x);
 }
 
 function setVelocityY(name, x) {
-  withSprite(name, (sprite) => {
-    if (sprite.body && sprite.body.enable) sprite.body.setVelocityY(x);
-  }, "setVelocityY()");
+  const sprite = scene[name];
+  sprite.body.setVelocityY(x);
 }
 
 function setBounce(name, x) {
@@ -345,7 +337,6 @@ function addKeyControl(key, browserActions = [], notifyServer = false) {
 
   const handler = function(e) {
     if (key === e.code) {
-      e.preventDefault();
       runBrowserActionList(browserActions);
       if (notifyServer) {
         Shiny.setInputValue(key + "_action", { code: e.code, evt_nonce: Date.now() + Math.random() }, { priority: "event" });

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -55,7 +55,7 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
     frameHeight: frameHeight
   });
 
-  scene.load.once(`filecomplete-spritesheet-${name}`, () => {
+  scene.load.once('complete', () => {
     const resolvedFrameCount = resolveFrameCount(name, frameWidth, frameHeight, frameCount);
 
     scene.anims.create({
@@ -86,12 +86,12 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
     }
   });
 
-  if (!scene.load.isLoading()) scene.load.start();
+  scene.load.start();
 }
 
 function addStaticSprite(name, url, x, y) {
   scene.load.image(name, url);
-  scene.load.once(`filecomplete-image-${name}`, () => {
+  scene.load.once('complete', () => {
     const staticSprite = scene.physics.add.staticSprite(x, y, name).setName(name);
     if (scene.terrainLayer) {
       scene.physics.add.collider(staticSprite, scene.terrainLayer);
@@ -108,7 +108,7 @@ function addStaticSprite(name, url, x, y) {
       applyPendingTerrainColliders();
     }
   });
-  if (!scene.load.isLoading()) scene.load.start();
+  scene.load.start();
 }
 
 function addSpriteAnimation(name, suffix, url, frameWidth, frameHeight, frameCount, frameRate) {
@@ -121,7 +121,7 @@ function addSpriteAnimation(name, suffix, url, frameWidth, frameHeight, frameCou
     frameWidth:  frameWidth,
     frameHeight: frameHeight
   });
-  scene.load.once(`filecomplete-spritesheet-${animKey}`, () => {
+  scene.load.once("complete", () => {
     const resolvedFrameCount = resolveFrameCount(animKey, frameWidth, frameHeight, frameCount);
 
     scene.anims.create({
@@ -134,7 +134,7 @@ function addSpriteAnimation(name, suffix, url, frameWidth, frameHeight, frameCou
       repeat: -1
     });
   });
-  if (!scene.load.isLoading()) scene.load.start();
+  scene.load.start();
 }
 
 

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -73,6 +73,9 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
     sprite.play(name + '_idle');
 
     scene[name] = sprite;
+    if (typeof applyPendingObjectColliders === "function") {
+      applyPendingObjectColliders();
+    }
     applyPendingSpriteActions(name);
 
     if (typeof applyPendingCameraFollows === "function") {
@@ -97,6 +100,9 @@ function addStaticSprite(name, url, x, y) {
       scene.physics.add.collider(staticSprite, scene.terrainLayer);
     }
     scene[name] = staticSprite;
+    if (typeof applyPendingObjectColliders === "function") {
+      applyPendingObjectColliders();
+    }
 
     if (typeof applyPendingCameraFollows === "function") {
       applyPendingCameraFollows();
@@ -180,6 +186,10 @@ function playAnimationForDuration(name, animName, duration) {
 }
 
 function setGravity(name, x, y) {
+  if (typeof hasPendingObjectCollider === "function" && hasPendingObjectCollider(name)) {
+    GameBridge.pendingGravity[name] = { x, y };
+    return;
+  }
   withSprite(name, (sprite) => {
     if (sprite.body) sprite.body.setGravity(x, y);
   }, "setGravity()");

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -73,9 +73,6 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
     sprite.play(name + '_idle');
 
     scene[name] = sprite;
-    if (typeof applyPendingObjectColliders === "function") {
-      applyPendingObjectColliders();
-    }
     applyPendingSpriteActions(name);
 
     if (typeof applyPendingCameraFollows === "function") {
@@ -100,9 +97,6 @@ function addStaticSprite(name, url, x, y) {
       scene.physics.add.collider(staticSprite, scene.terrainLayer);
     }
     scene[name] = staticSprite;
-    if (typeof applyPendingObjectColliders === "function") {
-      applyPendingObjectColliders();
-    }
 
     if (typeof applyPendingCameraFollows === "function") {
       applyPendingCameraFollows();
@@ -186,12 +180,12 @@ function playAnimationForDuration(name, animName, duration) {
 }
 
 function setGravity(name, x, y) {
-  if (typeof hasPendingObjectCollider === "function" && hasPendingObjectCollider(name)) {
-    GameBridge.pendingGravity[name] = { x, y };
-    return;
-  }
   withSprite(name, (sprite) => {
-    if (sprite.body) sprite.body.setGravity(x, y);
+    if (typeof sprite.setGravity === "function") {
+      sprite.setGravity(x, y);
+    } else if (sprite.body && typeof sprite.body.setGravity === "function") {
+      sprite.body.setGravity(x, y);
+    }
   }, "setGravity()");
 }
 

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -186,13 +186,15 @@ function setGravity(name, x, y) {
 }
 
 function setVelocityX(name, x) {
-  const sprite = scene[name];
-  sprite.body.setVelocityX(x);
+  withSprite(name, (sprite) => {
+    if (sprite.body && sprite.body.enable) sprite.body.setVelocityX(x);
+  }, "setVelocityX()");
 }
 
 function setVelocityY(name, x) {
-  const sprite = scene[name];
-  sprite.body.setVelocityY(x);
+  withSprite(name, (sprite) => {
+    if (sprite.body && sprite.body.enable) sprite.body.setVelocityY(x);
+  }, "setVelocityY()");
 }
 
 function setBounce(name, x) {
@@ -337,6 +339,7 @@ function addKeyControl(key, browserActions = [], notifyServer = false) {
 
   const handler = function(e) {
     if (key === e.code) {
+      e.preventDefault();
       runBrowserActionList(browserActions);
       if (notifyServer) {
         Shiny.setInputValue(key + "_action", { code: e.code, evt_nonce: Date.now() + Math.random() }, { priority: "event" });

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -73,6 +73,9 @@ function addSprite(name, url, x, y, frameWidth, frameHeight, frameCount, frameRa
     sprite.play(name + '_idle');
 
     scene[name] = sprite;
+    if (typeof freezePendingColliderBody === "function") {
+      freezePendingColliderBody(name);
+    }
     applyPendingSpriteActions(name);
 
     if (typeof applyPendingCameraFollows === "function") {
@@ -97,6 +100,9 @@ function addStaticSprite(name, url, x, y) {
       scene.physics.add.collider(staticSprite, scene.terrainLayer);
     }
     scene[name] = staticSprite;
+    if (typeof freezePendingColliderBody === "function") {
+      freezePendingColliderBody(name);
+    }
 
     if (typeof applyPendingCameraFollows === "function") {
       applyPendingCameraFollows();

--- a/man/PhaserGame.Rd
+++ b/man/PhaserGame.Rd
@@ -59,7 +59,7 @@ game <- PhaserGame$new(id = "my_game", width = 1024, height = 768)
 \subsection{Method \code{new()}}{
 Create a PhaserGame object with the given configuration.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$new(id = "phaser_game", width = 800, height = 600)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PhaserGame$new(id = "phaser_game", width = 800, height = 600, gravity_x = 0, gravity_y = 0)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -70,6 +70,10 @@ Create a PhaserGame object with the given configuration.
 \item{\code{width}}{Numeric. Width of the Phaser canvas in pixels (defaults to 800).}
 
 \item{\code{height}}{Numeric. Height of the Phaser canvas in pixels (defaults to 600).}
+
+\item{\code{gravity_x}}{Numeric. Horizontal Arcade Physics world gravity (defaults to 0).}
+
+\item{\code{gravity_y}}{Numeric. Vertical Arcade Physics world gravity (defaults to 0).}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -152,6 +152,14 @@ test_that("PhaserGame exposes use_phaser UI initializer", {
   expect_null(game$ui)
 })
 
+test_that("PhaserGame passes world gravity to its browser configuration", {
+  game <- PhaserGame$new(gravity_x = 10, gravity_y = 1200)
+  ui <- as.character(game$use_phaser())
+
+  expect_true(any(grepl('"gravity_x":10', ui, fixed = TRUE)))
+  expect_true(any(grepl('"gravity_y":1200', ui, fixed = TRUE)))
+})
+
 test_that("Sound methods send expected JS", {
   session <- make_mock_session()
   sound <- Sound$new("coin", "coin.mp3", volume = 0.5, loop = FALSE, session = session)
@@ -347,11 +355,11 @@ test_that("runtime visual assets initialize when the loader batch completes", {
   expect_false(any(grepl("if (!scene.load.isLoading())", sprite_js, fixed = TRUE)))
 })
 
-test_that("gravity uses the Arcade Sprite API and passive colliders have no callback", {
+test_that("bear uses Arcade world gravity", {
   game_js <- readLines(system.file("www", "phaser-game.js", package = "shinyphaser"), warn = FALSE)
-  sprite_js <- readLines(system.file("www", "phaser-sprite.js", package = "shinyphaser"), warn = FALSE)
+  bear <- readLines(system.file("examples", "bear.R", package = "shinyphaser"), warn = FALSE)
 
-  expect_true(any(grepl('typeof sprite.setGravity === "function"', sprite_js, fixed = TRUE)))
-  expect_true(any(grepl("const collisionCallback = (inputId || hasBrowserActions)", game_js, fixed = TRUE)))
-  expect_true(any(grepl(": null;", game_js, fixed = TRUE)))
+  expect_true(any(grepl("gravity: {", game_js, fixed = TRUE)))
+  expect_true(any(grepl("gravity_y = 1200", bear, fixed = TRUE)))
+  expect_false(any(grepl("$set_gravity", bear, fixed = TRUE)))
 })

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -346,3 +346,16 @@ test_that("runtime visual assets initialize when the loader batch completes", {
   expect_true(any(grepl("scene.load.once('complete'", image_js, fixed = TRUE)))
   expect_false(any(grepl("if (!scene.load.isLoading())", sprite_js, fixed = TRUE)))
 })
+
+test_that("gravity waits for pending object colliders", {
+  game_js <- readLines(system.file("www", "phaser-game.js", package = "shinyphaser"), warn = FALSE)
+  sprite_js <- readLines(system.file("www", "phaser-sprite.js", package = "shinyphaser"), warn = FALSE)
+  bear <- readLines(system.file("examples", "bear.R", package = "shinyphaser"), warn = FALSE)
+
+  expect_true(any(grepl("pendingObjectColliders", game_js, fixed = TRUE)))
+  expect_true(any(grepl("applyPendingObjectColliders()", sprite_js, fixed = TRUE)))
+  expect_true(any(grepl("hasPendingObjectCollider(name)", sprite_js, fixed = TRUE)))
+  expect_gt(which(grepl('object_two = "grass"', bear, fixed = TRUE))[1], 0)
+  expect_gt(which(grepl("bear$set_gravity", bear, fixed = TRUE))[1],
+            which(grepl('object_two = "grass"', bear, fixed = TRUE))[1])
+})

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -150,6 +150,18 @@ test_that("PhaserGame exposes use_phaser UI initializer", {
 
   expect_true(is.function(game$use_phaser))
   expect_null(game$ui)
+
+  ui <- game$use_phaser()
+  dependency <- Filter(
+    function(item) inherits(item, "html_dependency") &&
+      identical(item$name, "shinyphaser-assets"),
+    unclass(ui)
+  )
+  expect_length(dependency, 1)
+  expect_identical(
+    dependency[[1]]$version,
+    as.character(utils::packageVersion("shinyphaser"))
+  )
 })
 
 test_that("Sound methods send expected JS", {

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -323,19 +323,6 @@ test_that("dungeonheroes Space action retains interactions and combat", {
   expect_false(any(grepl("client_action", example, fixed = TRUE)))
 })
 
-test_that("bear starts on its platform and handles jumping on the server", {
-  example <- readLines(
-    system.file("examples", "bear.R", package = "shinyphaser"),
-    warn = FALSE
-  )
-
-  expect_true(any(grepl("y = 660", example, fixed = TRUE)))
-  expect_true(any(grepl("y = 670", example, fixed = TRUE)))
-  expect_true(any(grepl("frame_count = 10", example, fixed = TRUE)))
-  expect_true(any(grepl("notify_server = TRUE", example, fixed = TRUE)))
-  expect_true(any(grepl("input$Space_action", example, fixed = TRUE)))
-})
-
 test_that("browser feedback is configured for immediate visibility and audio", {
   game_js <- readLines(system.file("www", "phaser-game.js", package = "shinyphaser"), warn = FALSE)
   sprite_js <- readLines(system.file("www", "phaser-sprite.js", package = "shinyphaser"), warn = FALSE)
@@ -347,6 +334,15 @@ test_that("browser feedback is configured for immediate visibility and audio", {
   expect_true(any(grepl("filecomplete-audio-${name}", game_js, fixed = TRUE)))
   expect_true(any(grepl("if (!scene.load.isLoading()) scene.load.start()", game_js, fixed = TRUE)))
   expect_true(any(grepl("() => addCollider(objectOneName", game_js, fixed = TRUE)))
-  expect_true(any(grepl("filecomplete-spritesheet-${name}", sprite_js, fixed = TRUE)))
-  expect_true(any(grepl("filecomplete-image-${name}", sprite_js, fixed = TRUE)))
+})
+
+test_that("runtime visual assets initialize when the loader batch completes", {
+  sprite_js <- readLines(system.file("www", "phaser-sprite.js", package = "shinyphaser"), warn = FALSE)
+  group_js <- readLines(system.file("www", "phaser-groups.js", package = "shinyphaser"), warn = FALSE)
+  image_js <- readLines(system.file("www", "phaser-image.js", package = "shinyphaser"), warn = FALSE)
+
+  expect_true(any(grepl("scene.load.once('complete'", sprite_js, fixed = TRUE)))
+  expect_true(any(grepl("scene.load.once('complete'", group_js, fixed = TRUE)))
+  expect_true(any(grepl("scene.load.once('complete'", image_js, fixed = TRUE)))
+  expect_false(any(grepl("if (!scene.load.isLoading())", sprite_js, fixed = TRUE)))
 })

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -242,6 +242,20 @@ test_that("PhaserGame action blocks compile R6 calls for immediate execution", {
   expect_true(any(grepl('"disable_overlap_member":"apples"', msgs, fixed = TRUE)))
 })
 
+test_that("non-notifying physics handlers serialize a JavaScript null target", {
+  session <- make_mock_session()
+  game <- PhaserGame$new()
+  game$set_shiny_session(session)
+
+  game$add_collider("hero", "ground")
+  game$add_overlap("hero", "coin")
+
+  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
+  expect_true(any(grepl("addCollider('hero','ground',null,", msgs, fixed = TRUE)))
+  expect_true(any(grepl('addOverlap("hero", "coin", null,', msgs, fixed = TRUE)))
+  expect_false(any(grepl("[object Object]", msgs, fixed = TRUE)))
+})
+
 test_that("public handlers no longer expose client action lists", {
   game <- PhaserGame$new()
 
@@ -342,6 +356,7 @@ test_that("browser feedback is configured for immediate visibility and audio", {
   expect_true(any(grepl("filecomplete-audio-${name}", game_js, fixed = TRUE)))
   expect_true(any(grepl("if (!scene.load.isLoading()) scene.load.start()", game_js, fixed = TRUE)))
   expect_true(any(grepl("() => addCollider(objectOneName", game_js, fixed = TRUE)))
+  expect_true(any(grepl('typeof target !== "string"', game_js, fixed = TRUE)))
 })
 
 test_that("runtime visual assets initialize when the loader batch completes", {

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -341,6 +341,9 @@ test_that("browser feedback is configured for immediate visibility and audio", {
   expect_true(any(grepl("scene.input.keyboard.addCapture", game_js, fixed = TRUE)))
   expect_true(any(grepl('withSprite(name, (sprite) => {', sprite_js, fixed = TRUE)))
   expect_true(any(grepl("e.preventDefault()", sprite_js, fixed = TRUE)))
+  expect_true(any(grepl("freezePendingColliderBody(name)", game_js, fixed = TRUE)))
+  expect_true(any(grepl("releasePendingColliderBodies", game_js, fixed = TRUE)))
+  expect_true(any(grepl('typeof freezePendingColliderBody === "function"', sprite_js, fixed = TRUE)))
 })
 
 test_that("bear controls compile movement and jump as browser actions", {

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -150,18 +150,6 @@ test_that("PhaserGame exposes use_phaser UI initializer", {
 
   expect_true(is.function(game$use_phaser))
   expect_null(game$ui)
-
-  ui <- game$use_phaser()
-  dependency <- Filter(
-    function(item) inherits(item, "html_dependency") &&
-      identical(item$name, "shinyphaser-assets"),
-    unclass(ui)
-  )
-  expect_length(dependency, 1)
-  expect_identical(
-    dependency[[1]]$version,
-    as.character(utils::packageVersion("shinyphaser"))
-  )
 })
 
 test_that("Sound methods send expected JS", {
@@ -335,6 +323,19 @@ test_that("dungeonheroes Space action retains interactions and combat", {
   expect_false(any(grepl("client_action", example, fixed = TRUE)))
 })
 
+test_that("bear starts on its platform and handles jumping on the server", {
+  example <- readLines(
+    system.file("examples", "bear.R", package = "shinyphaser"),
+    warn = FALSE
+  )
+
+  expect_true(any(grepl("y = 660", example, fixed = TRUE)))
+  expect_true(any(grepl("y = 670", example, fixed = TRUE)))
+  expect_true(any(grepl("frame_count = 10", example, fixed = TRUE)))
+  expect_true(any(grepl("notify_server = TRUE", example, fixed = TRUE)))
+  expect_true(any(grepl("input$Space_action", example, fixed = TRUE)))
+})
+
 test_that("browser feedback is configured for immediate visibility and audio", {
   game_js <- readLines(system.file("www", "phaser-game.js", package = "shinyphaser"), warn = FALSE)
   sprite_js <- readLines(system.file("www", "phaser-sprite.js", package = "shinyphaser"), warn = FALSE)
@@ -348,23 +349,4 @@ test_that("browser feedback is configured for immediate visibility and audio", {
   expect_true(any(grepl("() => addCollider(objectOneName", game_js, fixed = TRUE)))
   expect_true(any(grepl("filecomplete-spritesheet-${name}", sprite_js, fixed = TRUE)))
   expect_true(any(grepl("filecomplete-image-${name}", sprite_js, fixed = TRUE)))
-  expect_true(any(grepl("disableVisibilityChange: true", game_js, fixed = TRUE)))
-  expect_true(any(grepl("!sprite.body || !sprite.body.enable", game_js, fixed = TRUE)))
-  expect_true(any(grepl("scene.input.keyboard.addCapture", game_js, fixed = TRUE)))
-  expect_true(any(grepl('withSprite(name, (sprite) => {', sprite_js, fixed = TRUE)))
-  expect_true(any(grepl("e.preventDefault()", sprite_js, fixed = TRUE)))
-  expect_true(any(grepl("freezePendingColliderBody(name)", game_js, fixed = TRUE)))
-  expect_true(any(grepl("releasePendingColliderBodies", game_js, fixed = TRUE)))
-  expect_true(any(grepl('typeof freezePendingColliderBody === "function"', sprite_js, fixed = TRUE)))
-})
-
-test_that("bear controls compile movement and jump as browser actions", {
-  example <- readLines(
-    system.file("examples", "bear.R", package = "shinyphaser"),
-    warn = FALSE
-  )
-
-  expect_true(any(grepl('directions = c("left", "right")', example, fixed = TRUE)))
-  expect_true(any(grepl('"Space"', example, fixed = TRUE)))
-  expect_true(any(grepl("bear$set_velocity_y(-600)", example, fixed = TRUE)))
 })

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -347,15 +347,11 @@ test_that("runtime visual assets initialize when the loader batch completes", {
   expect_false(any(grepl("if (!scene.load.isLoading())", sprite_js, fixed = TRUE)))
 })
 
-test_that("gravity waits for pending object colliders", {
+test_that("gravity uses the Arcade Sprite API and passive colliders have no callback", {
   game_js <- readLines(system.file("www", "phaser-game.js", package = "shinyphaser"), warn = FALSE)
   sprite_js <- readLines(system.file("www", "phaser-sprite.js", package = "shinyphaser"), warn = FALSE)
-  bear <- readLines(system.file("examples", "bear.R", package = "shinyphaser"), warn = FALSE)
 
-  expect_true(any(grepl("pendingObjectColliders", game_js, fixed = TRUE)))
-  expect_true(any(grepl("applyPendingObjectColliders()", sprite_js, fixed = TRUE)))
-  expect_true(any(grepl("hasPendingObjectCollider(name)", sprite_js, fixed = TRUE)))
-  expect_gt(which(grepl('object_two = "grass"', bear, fixed = TRUE))[1], 0)
-  expect_gt(which(grepl("bear$set_gravity", bear, fixed = TRUE))[1],
-            which(grepl('object_two = "grass"', bear, fixed = TRUE))[1])
+  expect_true(any(grepl('typeof sprite.setGravity === "function"', sprite_js, fixed = TRUE)))
+  expect_true(any(grepl("const collisionCallback = (inputId || hasBrowserActions)", game_js, fixed = TRUE)))
+  expect_true(any(grepl(": null;", game_js, fixed = TRUE)))
 })

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -336,6 +336,7 @@ test_that("browser feedback is configured for immediate visibility and audio", {
   expect_true(any(grepl("() => addCollider(objectOneName", game_js, fixed = TRUE)))
   expect_true(any(grepl("filecomplete-spritesheet-${name}", sprite_js, fixed = TRUE)))
   expect_true(any(grepl("filecomplete-image-${name}", sprite_js, fixed = TRUE)))
+  expect_true(any(grepl("disableVisibilityChange: true", game_js, fixed = TRUE)))
   expect_true(any(grepl("!sprite.body || !sprite.body.enable", game_js, fixed = TRUE)))
   expect_true(any(grepl("scene.input.keyboard.addCapture", game_js, fixed = TRUE)))
   expect_true(any(grepl('withSprite(name, (sprite) => {', sprite_js, fixed = TRUE)))

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -336,4 +336,19 @@ test_that("browser feedback is configured for immediate visibility and audio", {
   expect_true(any(grepl("() => addCollider(objectOneName", game_js, fixed = TRUE)))
   expect_true(any(grepl("filecomplete-spritesheet-${name}", sprite_js, fixed = TRUE)))
   expect_true(any(grepl("filecomplete-image-${name}", sprite_js, fixed = TRUE)))
+  expect_true(any(grepl("!sprite.body || !sprite.body.enable", game_js, fixed = TRUE)))
+  expect_true(any(grepl("scene.input.keyboard.addCapture", game_js, fixed = TRUE)))
+  expect_true(any(grepl('withSprite(name, (sprite) => {', sprite_js, fixed = TRUE)))
+  expect_true(any(grepl("e.preventDefault()", sprite_js, fixed = TRUE)))
+})
+
+test_that("bear controls compile movement and jump as browser actions", {
+  example <- readLines(
+    system.file("examples", "bear.R", package = "shinyphaser"),
+    warn = FALSE
+  )
+
+  expect_true(any(grepl('directions = c("left", "right")', example, fixed = TRUE)))
+  expect_true(any(grepl('"Space"', example, fixed = TRUE)))
+  expect_true(any(grepl("bear$set_velocity_y(-600)", example, fixed = TRUE)))
 })


### PR DESCRIPTION
### Motivation
- The bear example could become unresponsive: stale key handlers and browser default scrolling could prevent arrow keys and `Space` from controlling the player, and velocity updates could run when sprites or physics bodies were not ready causing the game to stop progressing.
- The `Space` action played sound but did not reliably apply upward velocity because velocity mutations were sent to the client before the sprite body existed or was enabled.

### Description
- Reset client-side control state on scene initialization by clearing `GameBridge.playerControls`, `GameBridge.forcedAnimations`, and removing existing `GameBridge.keyControlHandlers` so reconnects do not leave stale handlers in place, and reinitialize the handler map.
- Guard the player update loop by skipping entries where the sprite is missing, inactive, or has no enabled physics body using checks like `!sprite || !sprite.active || !sprite.body || !sprite.body.enable` to avoid freezing when objects fall or are not yet ready.
- Queue and guard velocity updates by switching `setVelocityX`/`setVelocityY` to use `withSprite(...)` so velocity is applied only when the sprite exists and has an enabled body, and prevent the browser default behavior for keydown events with `e.preventDefault()` in `addKeyControl`.
- Capture configured cursor keys via `scene.input.keyboard.addCapture(...)` so embedded pages do not let the browser steal arrow/space events, and add tests verifying the presence of the new protections and that the bear example compiles the movement/jump actions as browser-side actions.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors and succeeded. 
- Ran `node --check inst/www/phaser-game.js` and `node --check inst/www/phaser-sprite.js` which passed with no syntax errors. 
- Updated `tests/testthat/test-core-methods.R` to add regression assertions for the new guards and key-handling behavior, however the `testthat` suite was not run because R is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a42a2f294832f9efd7e44cce84f98)