### PR TITLE
Keep asynchronously loaded tilemaps behind scene objects

### DIFF
--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -375,6 +375,9 @@ function addMap(mapKey, mapUrl, tilesetUrls, tilesetNames, layerName) {
 
     const groundLayer = map.createLayer(layerName, phaserTilesets, 0, 0);
 
+    // Map assets load asynchronously, so the layer can be created after UI and
+    // game objects. Keep this background behind them regardless of load order.
+    groundLayer.setDepth(-1);
     groundLayer.setCollisionByProperty({ collides: true });
 
     scene.physics.world.bounds.width  = map.widthInPixels;

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -415,6 +415,31 @@ test_that("dungeonheroes tree has a collidable base and foreground top", {
   expect_true(any(grepl("dead_tree_top$set_depth(20)", example, fixed = TRUE)))
 })
 
+test_that("tilemaps stay behind objects created before they finish loading", {
+  game_js <- readLines(
+    system.file("www", "phaser-game.js", package = "shinyphaser"),
+    warn = FALSE
+  )
+
+  layer_creation <- grep(
+    "const groundLayer = map.createLayer(layerName, phaserTilesets, 0, 0);",
+    game_js,
+    fixed = TRUE
+  )
+  background_depth <- grep("groundLayer.setDepth(-1);", game_js, fixed = TRUE)
+  layer_collision <- grep(
+    "groundLayer.setCollisionByProperty({ collides: true });",
+    game_js,
+    fixed = TRUE
+  )
+
+  expect_length(layer_creation, 1)
+  expect_length(background_depth, 1)
+  expect_length(layer_collision, 1)
+  expect_lt(layer_creation, background_depth)
+  expect_lt(background_depth, layer_collision)
+})
+
 test_that("sight approach does not restart active movement or hide alerts", {
   sprite_js <- readLines(
     system.file("www", "phaser-sprite.js", package = "shinyphaser"),


### PR DESCRIPTION
### Motivation

- Tilemap layers created after other scene objects could render above HUD text and life bars due to asynchronous asset loading, causing intermittent visual overlap.

### Description

- Set the tilemap ground layer depth to `-1` immediately after layer creation in `inst/www/phaser-game.js` to force the map to render behind other scene objects.
- Added a regression test in `tests/testthat/test-core-methods.R` that verifies the `groundLayer` is created, `setDepth(-1)` is applied, and collision setup follows.

### Testing

- Ran `node --check inst/www/phaser-game.js`, which succeeded. 
- Ran `git diff --check`, which reported no issues. 
- Attempted `Rscript -e 'devtools::test()'` but the R runtime is unavailable in the environment, so the R test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6de24f0fbc832f9b40b0ae55371a10)