### PR TITLE
Add show/hide visibility controls for sprites and groups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # shinyphaser (development version)
 
+* Added `show()` and `hide()` methods to `Sprite`, `StaticSprite`, `Group`, and
+  `StaticGroup`; these methods also work in `browser_actions()`.
 * Split event handling into explicit `browser_action` and `server_action`
   parameters. Browser-side calls must now be declared with `browser_actions()`,
   while arbitrary R logic belongs in a server action.

--- a/R/groups.R
+++ b/R/groups.R
@@ -45,6 +45,16 @@ Group <- R6::R6Class(
         private$name, x, y
       )
       send_js(private, js)
+    },
+    #' @description Show all current members of this group.
+    #' @return Invisible; sends a custom message to the client.
+    show = function() {
+      send_js(private, sprintf("showObject('%s');", private$name))
+    },
+    #' @description Hide all current members of this group.
+    #' @return Invisible; sends a custom message to the client.
+    hide = function() {
+      send_js(private, sprintf("hideObject('%s');", private$name))
     }
   ),
   private = list(
@@ -82,6 +92,16 @@ StaticGroup <- R6::R6Class(
         private$name, x, y
       )
       send_js(private, js)
+    },
+    #' @description Show all current members of this static group.
+    #' @return Invisible; sends a custom message to the client.
+    show = function() {
+      send_js(private, sprintf("showObject('%s');", private$name))
+    },
+    #' @description Hide all current members of this static group.
+    #' @return Invisible; sends a custom message to the client.
+    hide = function() {
+      send_js(private, sprintf("hideObject('%s');", private$name))
     },
     #' @description Disable a static group member body based on overlap event payload.
     #' @param evt List-like event payload containing x2 and y2 values.

--- a/R/sprites.R
+++ b/R/sprites.R
@@ -79,6 +79,18 @@ Sprite <- R6::R6Class(
       send_js(private, sprintf("stopSpriteMotion('%s');", private$name))
     },
 
+    #' @description Show this sprite.
+    #' @return Invisible; sends a custom message to the client.
+    show = function() {
+      send_js(private, sprintf("showObject('%s');", private$name))
+    },
+
+    #' @description Hide this sprite.
+    #' @return Invisible; sends a custom message to the client.
+    hide = function() {
+      send_js(private, sprintf("hideObject('%s');", private$name))
+    },
+
     #' @description Enable movement controls (arrow keys) for a player sprite.
     #' @param directions Character vector. Directions to enable (defaults to c("left","right","down","up")).
     #' @param speed Numeric. Movement speed in pixels/second (default: 200).
@@ -170,7 +182,6 @@ Sprite <- R6::R6Class(
                     private$name)
       send_js(private, js)
     },
-
     #' @description Move sprite along a vector for a set distance.
     #' @param dir_x Numeric. Horizontal direction (-1 = left, +1 = right, 0 = none).
     #' @param dir_y Numeric. Vertical direction (-1 = up, +1 = down, 0 = none).
@@ -274,6 +285,16 @@ StaticSprite <- R6::R6Class(
       js <- sprintf("destroySprite('%s');",
                     private$name)
       send_js(private, js)
+    },
+    #' @description Show this static sprite.
+    #' @return Invisible; sends a custom message to the client.
+    show = function() {
+      send_js(private, sprintf("showObject('%s');", private$name))
+    },
+    #' @description Hide this static sprite.
+    #' @return Invisible; sends a custom message to the client.
+    hide = function() {
+      send_js(private, sprintf("hideObject('%s');", private$name))
     },
     #' @description Make the camera follow this static sprite as it moves through the world.
     #' @param lerp_x Numeric. Horizontal interpolation factor from 0 to 1 (default: 1).

--- a/R/utils.R
+++ b/R/utils.R
@@ -174,6 +174,14 @@ compile_phaser_action_call <- function(expr, env) {
   if (inherits(target, c("Image", "Rectangle")) && method == "hide") {
     return(list(hide_text = object_name))
   }
+  if (inherits(target, c("Sprite", "StaticSprite", "Group", "StaticGroup")) &&
+      method == "show") {
+    return(list(show_object = object_name))
+  }
+  if (inherits(target, c("Sprite", "StaticSprite", "Group", "StaticGroup")) &&
+      method == "hide") {
+    return(list(hide_object = object_name))
+  }
   if (inherits(target, "Sound") && method == "play") {
     action <- list(play_sound = object_name)
     volume <- value("volume", 1)

--- a/inst/www/phaser-sprite.js
+++ b/inst/www/phaser-sprite.js
@@ -116,6 +116,33 @@ function addStaticSprite(name, url, x, y) {
   scene.load.start();
 }
 
+function setObjectVisible(name, visible) {
+  const object = scene && scene[name];
+  if (!object) {
+    withSprite(name, (sprite) => sprite.setVisible(visible), "setObjectVisible()");
+    return;
+  }
+
+  if (typeof object.setVisible === "function") {
+    object.setVisible(visible);
+    return;
+  }
+
+  // Phaser groups are not display objects, so visibility must be applied to
+  // each of their current members.
+  if (typeof object.getChildren === "function") {
+    object.getChildren().forEach((child) => child.setVisible(visible));
+  }
+}
+
+function showObject(name) {
+  setObjectVisible(name, true);
+}
+
+function hideObject(name) {
+  setObjectVisible(name, false);
+}
+
 function addSpriteAnimation(name, suffix, url, frameWidth, frameHeight, frameCount, frameRate) {
   if (!scene) {
     console.warn(`addSpriteAnimation("${name}", "${suffix}"): scene not ready`);
@@ -333,6 +360,8 @@ function runBrowserAction(action, overlapObjectOne, overlapObjectTwo) {
   }
   if (action.show_text) showText(action.show_text);
   if (action.hide_text) hideText(action.hide_text);
+  if (action.show_object) showObject(action.show_object);
+  if (action.hide_object) hideObject(action.hide_object);
   if (action.show_alert) {
     if (typeof swal === "function") swal(action.show_alert);
     else window.alert(action.show_alert.title || action.show_alert.text || "");

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -46,16 +46,24 @@ test_that("Group and StaticGroup methods send expected JS", {
   g <- Group$new("enemies", session = session)
   g$add_animation("walk", "enemy.png", 16, 16, 4, 10)
   g$create(50, 60)
+  g$hide()
+  g$show()
 
   sg <- StaticGroup$new("obstacles", "box.png", session = session)
   sg$create(5, 6)
+  sg$hide()
+  sg$show()
   sg$disable(list(x2 = 5, y2 = 6))
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
   expect_true(any(grepl("addGroup\\('enemies'\\);", msgs)))
   expect_true(any(grepl("addGroupAnimation\\('enemies','walk','enemy.png',16,16,4,10\\);", msgs)))
   expect_true(any(grepl("addToGroup\\('enemies', 50, 60\\);", msgs)))
+  expect_true(any(grepl("hideObject\\('enemies'\\);", msgs)))
+  expect_true(any(grepl("showObject\\('enemies'\\);", msgs)))
   expect_true(any(grepl("addStaticGroup\\('obstacles','box.png'\\);", msgs)))
+  expect_true(any(grepl("hideObject\\('obstacles'\\);", msgs)))
+  expect_true(any(grepl("showObject\\('obstacles'\\);", msgs)))
   expect_true(any(grepl("disableBody\\('obstacles', 5, 6\\);", msgs)))
 })
 
@@ -66,6 +74,8 @@ test_that("StaticSprite destroy sends expected JS", {
   static_sprite$stop_camera_follow()
   static_sprite$set_scroll_factor(0)
   static_sprite$set_depth(10)
+  static_sprite$hide()
+  static_sprite$show()
   static_sprite$destroy()
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
@@ -74,6 +84,8 @@ test_that("StaticSprite destroy sends expected JS", {
   expect_true(any(grepl("stopCameraFollow\\('rock'\\);", msgs)))
   expect_true(any(grepl("setScrollFactor\\('rock', 0.000000, 0.000000\\);", msgs)))
   expect_true(any(grepl("setSpriteDepth\\('rock', 10.000000\\);", msgs)))
+  expect_true(any(grepl("hideObject\\('rock'\\);", msgs)))
+  expect_true(any(grepl("showObject\\('rock'\\);", msgs)))
   expect_true(any(grepl("destroySprite\\('rock'\\);", msgs)))
 })
 
@@ -217,6 +229,8 @@ test_that("browser_actions compile R6 calls for immediate execution", {
     input = input,
     browser_action = browser_actions({
       prompt$show()
+      hero$hide()
+      hero$show()
       sound$play(volume = 0.5)
       hero$stop_motion()
       hero$play_animation("wave", duration = 250)
@@ -241,6 +255,8 @@ test_that("browser_actions compile R6 calls for immediate execution", {
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
   expect_true(any(grepl('addOverlap("hero", "wizard"', msgs, fixed = TRUE)))
   expect_true(any(grepl('"show_text":"prompt"', msgs, fixed = TRUE)))
+  expect_true(any(grepl('"hide_object":"hero"', msgs, fixed = TRUE)))
+  expect_true(any(grepl('"show_object":"hero"', msgs, fixed = TRUE)))
   expect_true(any(grepl('"play_sound":"hello","volume":0.5', msgs, fixed = TRUE)))
   expect_true(any(grepl('"stop_motion":"hero"', msgs, fixed = TRUE)))
   expect_true(any(grepl('"play_animation":"wave","sprite":"hero","duration":250', msgs, fixed = TRUE)))

--- a/tests/testthat/test-sprites.R
+++ b/tests/testthat/test-sprites.R
@@ -54,3 +54,15 @@ test_that("Sprite add_animation sends explicit frame_count when provided", {
   expect_length(msgs, 2)
   expect_match(msgs[[2]]$message$js, "addSpriteAnimation\\(\"hero\",\"run\",\"run.png\",32,32,6,24\\);")
 })
+
+test_that("Sprite show and hide send visibility commands", {
+  session <- make_mock_session()
+  sprite <- Sprite$new("hero", "hero.png", 0, 0, 16, 16, 1, 8, session)
+
+  sprite$hide()
+  sprite$show()
+
+  msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
+  expect_true(any(grepl("hideObject\\('hero'\\);", msgs)))
+  expect_true(any(grepl("showObject\\('hero'\\);", msgs)))
+})


### PR DESCRIPTION
### Motivation

- Sprites and groups lacked unified `show()`/`hide()` APIs and browser-action support for toggling visibility. 
- Browser-side visibility needs to work for asynchronously loaded sprites and for group members that are not display objects. 

### Description

- Added `show()` and `hide()` methods to `Sprite`, `StaticSprite`, `Group`, and `StaticGroup` that send `showObject()`/`hideObject()` commands to the client. 
- Implemented `setObjectVisible()`, `showObject()` and `hideObject()` in `inst/www/phaser-sprite.js` which queue actions with `withSprite()` when a sprite is not ready and apply visibility to groups by iterating `getChildren()`. 
- Extended the browser-action compiler in `R/utils.R` to emit `show_object`/`hide_object` actions and updated the JS `runBrowserAction` to execute these actions immediately in the browser. 
- Added unit tests under `tests/testthat/` to cover `show()`/`hide()` for animated/static sprites and dynamic/static groups and to exercise `browser_actions()` serialization, and documented the change in `NEWS.md`. 

### Testing

- Ran `node --check inst/www/phaser-sprite.js` which reported no syntax errors. 
- Ran `git diff --check HEAD^ HEAD` to validate whitespace/checks and it passed. 
- Added R unit tests but `Rscript -e 'testthat::test_local()'` could not be run in this environment because `Rscript` is not available, so the R test suite was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dfb6568d0832f9ed507e5af62e2d9)