### PR TITLE
Add hero and orc character selection screen

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * Queued sprite physics actions until sprites finish loading so setup calls such as `set_gravity()` are not lost during asynchronous asset initialization.
 
 ## New interface features
+* Added `Sprite$set_player_animation_prefix()` for switching the idle and directional movement animation set used by player controls at runtime.
 * Added `gravity_x` and `gravity_y` parameters to `PhaserGame$new()` for configuring Arcade Physics world gravity when a game is created.
 * Added sound support with `PhaserGame$add_sound()` and a new `Sound` API for loading, playing, pausing, resuming, stopping, and configuring audio.
 * Added `set_scroll_factor()` helpers for scene objects so HUD-style elements can stay fixed while the camera follows another target.

--- a/R/sprites.R
+++ b/R/sprites.R
@@ -89,6 +89,18 @@ Sprite <- R6::R6Class(
       send_js(private, js)
     },
 
+    #' @description Choose the animation prefix used by player controls.
+    #' @param prefix Character. Prefix for idle and directional movement animation keys.
+    #' @return Invisible; sends a custom message to the client.
+    set_player_animation_prefix = function(prefix) {
+      js <- sprintf(
+        "setPlayerAnimationPrefix(%s, %s);",
+        jsonlite::toJSON(private$name, auto_unbox = TRUE),
+        jsonlite::toJSON(prefix, auto_unbox = TRUE)
+      )
+      send_js(private, js)
+    },
+
     #' @description Make the camera follow this sprite as it moves through the world.
     #' @param lerp_x Numeric. Horizontal interpolation factor from 0 to 1 (default: 1).
     #' @param lerp_y Numeric. Vertical interpolation factor from 0 to 1 (default: 1).

--- a/R/utils.R
+++ b/R/utils.R
@@ -206,7 +206,7 @@ compile_phaser_action_call <- function(expr, env) {
     )))
   }
   if (inherits(target, "Sprite") && method %in% c("set_velocity_x", "set_velocity_y")) {
-    return(setNames(list(list(name = object_name, value = value("x", 1, 100))), method))
+    return(stats::setNames(list(list(name = object_name, value = value("x", 1, 100))), method))
   }
   if (inherits(target, "Sprite") && method == "stop_motion") {
     return(list(stop_motion = object_name))

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -159,7 +159,7 @@ ui <- shiny::tagList(
         id = "choose_hero", class = "character_choice action-button",
         type = "button",
         htmltools::tags$span(class = "character_portrait"),
-        htmltools::tags$span(class = "character_name", "Hero"),
+        htmltools::tags$span(class = "character_name", "Human"),
         htmltools::tags$span(class = "character_description", "Courage against the darkness")
       ),
       htmltools::tags$button(
@@ -992,7 +992,10 @@ server <- function(input, output, session) {
     hero$set_depth(10)
     session$sendCustomMessage(
       "phaser",
-      list(js = "document.getElementById('leave_map').style.display = 'block';")
+      list(js = paste(
+        "setRealmNavigationVisible(false);",
+        "document.getElementById('leave_map').style.display = 'block';"
+      ))
     )
   }
 
@@ -1002,18 +1005,16 @@ server <- function(input, output, session) {
     selected_character <<- character
     hero$add_player_controls()
     hero$set_player_animation_prefix(character)
-    play_hero_idle_animation()
     map_navigation_background$show()
     hero$set_depth(98)
     mushroom_swamps_map_image$show()
     magma_hills_map_image$show()
     session$sendCustomMessage(
       "phaser",
-      list(js = "document.getElementById('character_select').style.display = 'none';")
-    )
-    shinyalert::shinyalert(
-      title = "Use Space to attack and interact",
-      type = "info"
+      list(js = paste(
+        "setRealmNavigationVisible(true);",
+        "document.getElementById('character_select').style.display = 'none';"
+      ))
     )
   }
 
@@ -1025,6 +1026,9 @@ server <- function(input, output, session) {
   }, ignoreInit = TRUE)
 
   shiny::observeEvent(input$leave_map, {
+    session$sendCustomMessage(
+      "phaser", list(js = "setRealmNavigationVisible(true);")
+    )
     map_navigation_background$show()
     # Keep the player out of the realm navigation display by rendering it
     # behind the opaque navigation background.
@@ -1033,8 +1037,16 @@ server <- function(input, output, session) {
     magma_hills_map_image$show()
   }, ignoreInit = TRUE)
 
+  show_controls_alert <- function() {
+    shinyalert::shinyalert(
+      title = "Use Space to attack and interact",
+      type = "info"
+    )
+  }
+
   choose_mushroom_swamps <- function(event) {
     hide_map_navigation()
+    show_controls_alert()
     game$activate_map(
       "mushroom_swamps", player_name = "hero", x = 100, y = 100,
       visible_objects = mushroom_swamps_objects
@@ -1045,6 +1057,7 @@ server <- function(input, output, session) {
 
   choose_magma_hills <- function(event) {
     hide_map_navigation()
+    show_controls_alert()
     game$activate_map(
       # Magma hills has its own hill-top arrival point, separate from the
       # mushroom swamps entrance at (100, 100).

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -107,7 +107,7 @@ ui <- shiny::tagList(
     }
 
     #choose_hero .character_portrait {
-      background-image: url('assets/dungeonheroes/sprites/hero_idle.png');
+      background-image: url('assets/dungeonheroes/sprites/hero_sword_idle.png');
     }
 
     #choose_orc .character_portrait {
@@ -125,6 +125,40 @@ ui <- shiny::tagList(
       margin-top: 7px;
       color: #bcb59e;
       font: 15px sans-serif;
+    }
+
+    #realm_character_marker {
+      position: fixed;
+      z-index: 8500;
+      display: none;
+      width: 100px;
+      height: 100px;
+      border: 3px solid #f5d98b;
+      border-radius: 50%;
+      background-repeat: no-repeat;
+      background-color: rgba(17, 24, 39, 0.88);
+      box-shadow: 0 4px 14px #000;
+      image-rendering: pixelated;
+      pointer-events: none;
+      transform: translate(-50%, -50%);
+    }
+
+    #realm_character_marker.human {
+      background-image: url('assets/dungeonheroes/sprites/hero_sword_idle.png');
+    }
+
+    #realm_character_marker.orc {
+      background-image: url('assets/dungeonheroes/sprites/hero_orc_idle.png');
+    }
+
+    #realm_character_marker.mushroom_swamps {
+      left: 50%;
+      top: 50%;
+    }
+
+    #realm_character_marker.magma_hills {
+      left: 81.25%;
+      top: 87.5%;
     }
 
     #leave_map {
@@ -170,6 +204,11 @@ ui <- shiny::tagList(
         htmltools::tags$span(class = "character_description", "Strength born of the wilds")
       )
     )
+  ),
+  htmltools::tags$div(
+    id = "realm_character_marker",
+    class = "mushroom_swamps",
+    `aria-hidden` = "true"
   ),
   shiny::actionButton(
     "leave_map", "Leave map",
@@ -240,13 +279,10 @@ server <- function(input, output, session) {
   )
   enemy_attack_cooldown <- 2
   enemy_in_range <- NULL
-  sword_in_range <- FALSE
   wizard_in_range <- FALSE
   berry_in_range <- NULL
-  has_sword <- FALSE
   hero_last_attack_time <- as.numeric(Sys.time()) - 1
   hero_attack_cooldown <- 0.75
-  hero_fist_damage <- 1
   hero_sword_damage <- 2
   health_bar_segment_count <- 10
   health_bar_segment_width <- 18
@@ -255,6 +291,7 @@ server <- function(input, output, session) {
   game_over_shown <- FALSE
   defeated_enemy_count <- 0
   selected_character <- NULL
+  current_realm <- "mushroom_swamps"
 
   enemy_animation_key <- function(enemy_name, suffix) {
     paste(enemy_name, suffix, sep = "_")
@@ -341,18 +378,14 @@ server <- function(input, output, session) {
     if (identical(selected_character, "hero_orc")) {
       return("hero_orc_idle")
     }
-    if (has_sword) {
-      return("hero_sword_idle")
-    }
-
-    "hero_idle"
+    "hero_sword_idle"
   }
 
   hero_attack_animation <- function() {
     if (identical(selected_character, "hero_orc")) {
       return("hero_orc_attack")
     }
-    if (has_sword) "hero_sword_attack" else "hero_attack"
+    "hero_sword_attack"
   }
 
   play_hero_idle_animation <- function() {
@@ -461,7 +494,7 @@ server <- function(input, output, session) {
   )
   hero <- game$add_sprite(
     name = "hero",
-    url = "assets/dungeonheroes/sprites/hero_idle.png",
+    url = "assets/dungeonheroes/sprites/hero_sword_idle.png",
     x = 100,
     y = 100,
     frame_width = 100,
@@ -510,21 +543,21 @@ server <- function(input, output, session) {
     suffix = "orc_idle",
     url = "assets/dungeonheroes/sprites/hero_orc_idle.png",
     frame_width = 100, frame_height = 100,
-    frame_count = 7, frame_rate = 4
+    frame_count = 29, frame_rate = 4
   )
   lapply(c("down", "up", "left", "right"), function(direction) {
     hero$add_animation(
       suffix = paste0("orc_move_", direction),
       url = sprintf("assets/dungeonheroes/sprites/hero_orc_move_%s.png", direction),
       frame_width = 100, frame_height = 100,
-      frame_count = 4, frame_rate = 8
+      frame_count = 6, frame_rate = 8
     )
   })
   hero$add_animation(
     suffix = "orc_attack",
     url = "assets/dungeonheroes/sprites/hero_orc_attack.png",
     frame_width = 100, frame_height = 100,
-    frame_count = 2, frame_rate = 4
+    frame_count = 3, frame_rate = 4
   )
 
   hero$add_animation(
@@ -652,16 +685,6 @@ server <- function(input, output, session) {
         return(invisible(NULL))
       }
 
-      if (sword_in_range && !has_sword) {
-        has_sword <<- TRUE
-        sword_in_range <<- FALSE
-        sword$destroy()
-        inventory_text$set("weapon: sword")
-        play_hero_idle_animation()
-        set_combat_status("You picked up the sword.")
-        return(invisible(NULL))
-      }
-
       if (wizard_in_range) {
         shinyalert::shinyalert(
           title = "Dear, oh dear. What are you doing here in these dark forests, lad?",
@@ -680,7 +703,7 @@ server <- function(input, output, session) {
       hero_attack_sound$play()
 
       if (!is.null(enemy_in_range) && isTRUE(enemy_is_alive[[enemy_in_range]])) {
-        damage <- if (has_sword) hero_sword_damage else hero_fist_damage
+        damage <- hero_sword_damage
         hero_animation <- hero_attack_animation()
         enemy_hit_points[[enemy_in_range]] <<- max(0, enemy_hit_points[[enemy_in_range]] - damage)
         play_hero_timed_animation(hero_animation)
@@ -712,7 +735,7 @@ server <- function(input, output, session) {
   )
 
   inventory_text <- game$add_text(
-    text = "weapon: none",
+    text = "weapon: sword",
     id = "inventory_weapon",
     x = 1200,
     y = 85
@@ -751,7 +774,7 @@ server <- function(input, output, session) {
   )
   enemy_status_text$set_scroll_factor(0)
   combat_status_text <- game$add_text(
-    text = "combat: find a weapon, then face the enemies",
+    text = "combat: face the enemies and protect the realms",
     id = "combat_status",
     x = 800,
     y = 660
@@ -783,21 +806,6 @@ server <- function(input, output, session) {
   dead_tree_top$set_depth(20)
 
   game$add_collider("hero", "dead_tree_1_bottom")
-
-  sword <- game$add_static_sprite(
-    name = "sword",
-    url = "assets/dungeonheroes/weapons/sword.png",
-    x = 300,
-    y = 300
-  )
-  game$add_overlap(
-    "hero", "sword", input = input,
-    server_action = function(event) sword_in_range <<- TRUE
-  )
-  game$add_overlap_end(
-    "hero", "sword", input = input, session = session,
-    server_action = function(event) sword_in_range <<- FALSE
-  )
 
   berry_specs <- list(
     berries_1 = c(x = 650, y = 650),
@@ -982,7 +990,7 @@ server <- function(input, output, session) {
 
   mushroom_swamps_objects <- c(
     enemy_names,
-    "dead_tree_1_bottom", "dead_tree_1_top", "sword", names(berries),
+    "dead_tree_1_bottom", "dead_tree_1_top", names(berries),
     "wizard", "mushroom_spirit"
   )
 
@@ -993,7 +1001,7 @@ server <- function(input, output, session) {
     session$sendCustomMessage(
       "phaser",
       list(js = paste(
-        "setRealmNavigationVisible(false);",
+        "setNavigationOverlayVisible(false);",
         "document.getElementById('leave_map').style.display = 'block';"
       ))
     )
@@ -1004,7 +1012,9 @@ server <- function(input, output, session) {
 
     selected_character <<- character
     hero$add_player_controls()
-    hero$set_player_animation_prefix(character)
+    animation_prefix <- if (identical(character, "hero_orc")) character else "hero_sword"
+    marker_character <- if (identical(character, "hero_orc")) "orc" else "human"
+    hero$set_player_animation_prefix(animation_prefix)
     map_navigation_background$show()
     hero$set_depth(98)
     mushroom_swamps_map_image$show()
@@ -1012,7 +1022,11 @@ server <- function(input, output, session) {
     session$sendCustomMessage(
       "phaser",
       list(js = paste(
-        "setRealmNavigationVisible(true);",
+        sprintf(
+          "document.getElementById('realm_character_marker').className = '%s %s';",
+          marker_character, current_realm
+        ),
+        "setNavigationOverlayVisible(true);",
         "document.getElementById('character_select').style.display = 'none';"
       ))
     )
@@ -1027,7 +1041,7 @@ server <- function(input, output, session) {
 
   shiny::observeEvent(input$leave_map, {
     session$sendCustomMessage(
-      "phaser", list(js = "setRealmNavigationVisible(true);")
+      "phaser", list(js = "setNavigationOverlayVisible(true);")
     )
     map_navigation_background$show()
     # Keep the player out of the realm navigation display by rendering it
@@ -1045,6 +1059,11 @@ server <- function(input, output, session) {
   }
 
   choose_mushroom_swamps <- function(event) {
+    current_realm <<- "mushroom_swamps"
+    session$sendCustomMessage(
+      "phaser",
+      list(js = "document.getElementById('realm_character_marker').classList.replace('magma_hills', 'mushroom_swamps');")
+    )
     hide_map_navigation()
     show_controls_alert()
     game$activate_map(
@@ -1056,6 +1075,11 @@ server <- function(input, output, session) {
   }
 
   choose_magma_hills <- function(event) {
+    current_realm <<- "magma_hills"
+    session$sendCustomMessage(
+      "phaser",
+      list(js = "document.getElementById('realm_character_marker').classList.replace('mushroom_swamps', 'magma_hills');")
+    )
     hide_map_navigation()
     show_controls_alert()
     game$activate_map(

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -38,6 +38,95 @@ ui <- shiny::tagList(
       image-rendering: pixelated;
     }
 
+    #character_select {
+      position: fixed;
+      inset: 0;
+      z-index: 9500;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 28px;
+      overflow: hidden;
+      background:
+        radial-gradient(circle at 50% 35%, rgba(61, 81, 70, 0.9), transparent 38%),
+        linear-gradient(180deg, #17221e 0%, #080d0b 100%);
+      color: #f6e7bd;
+      font-family: Georgia, serif;
+    }
+
+    #character_select h1 {
+      margin: 0;
+      color: #f5d98b;
+      font-size: clamp(42px, 6vw, 76px);
+      letter-spacing: 0.08em;
+      text-shadow: 0 4px 0 #51351e, 0 8px 18px #000;
+    }
+
+    #character_select .select_prompt {
+      margin: -16px 0 4px;
+      color: #d8c9a3;
+      font: 600 22px sans-serif;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    #character_select .character_choices {
+      display: flex;
+      gap: clamp(24px, 6vw, 80px);
+    }
+
+    #character_select .character_choice {
+      width: 260px;
+      padding: 24px 20px 20px;
+      border: 3px solid #8f7140;
+      border-radius: 12px;
+      background: rgba(20, 27, 23, 0.94);
+      box-shadow: 0 10px 28px #000;
+      color: #f6e7bd;
+      cursor: pointer;
+      transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+    }
+
+    #character_select .character_choice:hover,
+    #character_select .character_choice:focus-visible {
+      transform: translateY(-7px) scale(1.02);
+      border-color: #f5d98b;
+      background: #28352e;
+      outline: none;
+    }
+
+    #character_select .character_portrait {
+      display: block;
+      width: 100px;
+      height: 100px;
+      margin: 0 auto 16px;
+      background-repeat: no-repeat;
+      image-rendering: pixelated;
+      transform: scale(1.35);
+    }
+
+    #choose_hero .character_portrait {
+      background-image: url('assets/dungeonheroes/sprites/hero_idle.png');
+    }
+
+    #choose_orc .character_portrait {
+      background-image: url('assets/dungeonheroes/sprites/hero_orc_idle.png');
+    }
+
+    #character_select .character_name {
+      display: block;
+      font: 700 28px Georgia, serif;
+      letter-spacing: 0.05em;
+    }
+
+    #character_select .character_description {
+      display: block;
+      margin-top: 7px;
+      color: #bcb59e;
+      font: 15px sans-serif;
+    }
+
     #leave_map {
       position: fixed;
       display: none;
@@ -59,6 +148,28 @@ ui <- shiny::tagList(
     id = "dungeonheroes_loader",
     htmltools::tags$div(class = "skeleton_loader_sprite"),
     htmltools::tags$div("Loading dungeon heroes...")
+  ),
+  htmltools::tags$div(
+    id = "character_select",
+    htmltools::tags$h1("DUNGEON HEROES"),
+    htmltools::tags$p(class = "select_prompt", "Choose your champion"),
+    htmltools::tags$div(
+      class = "character_choices",
+      htmltools::tags$button(
+        id = "choose_hero", class = "character_choice action-button",
+        type = "button",
+        htmltools::tags$span(class = "character_portrait"),
+        htmltools::tags$span(class = "character_name", "Hero"),
+        htmltools::tags$span(class = "character_description", "Courage against the darkness")
+      ),
+      htmltools::tags$button(
+        id = "choose_orc", class = "character_choice action-button",
+        type = "button",
+        htmltools::tags$span(class = "character_portrait"),
+        htmltools::tags$span(class = "character_name", "Orc"),
+        htmltools::tags$span(class = "character_description", "Strength born of the wilds")
+      )
+    )
   ),
   shiny::actionButton(
     "leave_map", "Leave map",
@@ -143,13 +254,7 @@ server <- function(input, output, session) {
   health_bar_segment_gap <- 3
   game_over_shown <- FALSE
   defeated_enemy_count <- 0
-
-  session$onFlushed(function() {
-    shinyalert::shinyalert(
-      title = "Use Space to attack and interact",
-      type = "info"
-    )
-  }, once = TRUE)
+  selected_character <- NULL
 
   enemy_animation_key <- function(enemy_name, suffix) {
     paste(enemy_name, suffix, sep = "_")
@@ -233,11 +338,21 @@ server <- function(input, output, session) {
   }
 
   hero_idle_animation <- function() {
+    if (identical(selected_character, "hero_orc")) {
+      return("hero_orc_idle")
+    }
     if (has_sword) {
-      return("hero_sword")
+      return("hero_sword_idle")
     }
 
-    "hero"
+    "hero_idle"
+  }
+
+  hero_attack_animation <- function() {
+    if (identical(selected_character, "hero_orc")) {
+      return("hero_orc_attack")
+    }
+    if (has_sword) "hero_sword_attack" else "hero_attack"
   }
 
   play_hero_idle_animation <- function() {
@@ -354,7 +469,6 @@ server <- function(input, output, session) {
     frame_count = 7,
     frame_rate = 4
   )
-  hero$add_player_controls()
   hero$follow_camera()
   hero$set_depth(10)
   game$set_map_exit("mushroom_swamps", "hero", x = 100, y = 100)
@@ -388,6 +502,27 @@ server <- function(input, output, session) {
   hero$add_animation(
     suffix = "attack",
     url = "assets/dungeonheroes/sprites/hero_attack.png",
+    frame_width = 100, frame_height = 100,
+    frame_count = 2, frame_rate = 4
+  )
+
+  hero$add_animation(
+    suffix = "orc_idle",
+    url = "assets/dungeonheroes/sprites/hero_orc_idle.png",
+    frame_width = 100, frame_height = 100,
+    frame_count = 7, frame_rate = 4
+  )
+  lapply(c("down", "up", "left", "right"), function(direction) {
+    hero$add_animation(
+      suffix = paste0("orc_move_", direction),
+      url = sprintf("assets/dungeonheroes/sprites/hero_orc_move_%s.png", direction),
+      frame_width = 100, frame_height = 100,
+      frame_count = 4, frame_rate = 8
+    )
+  })
+  hero$add_animation(
+    suffix = "orc_attack",
+    url = "assets/dungeonheroes/sprites/hero_orc_attack.png",
     frame_width = 100, frame_height = 100,
     frame_count = 2, frame_rate = 4
   )
@@ -522,7 +657,7 @@ server <- function(input, output, session) {
         sword_in_range <<- FALSE
         sword$destroy()
         inventory_text$set("weapon: sword")
-        hero$play_animation("hero_sword")
+        play_hero_idle_animation()
         set_combat_status("You picked up the sword.")
         return(invisible(NULL))
       }
@@ -546,7 +681,7 @@ server <- function(input, output, session) {
 
       if (!is.null(enemy_in_range) && isTRUE(enemy_is_alive[[enemy_in_range]])) {
         damage <- if (has_sword) hero_sword_damage else hero_fist_damage
-        hero_animation <- if (has_sword) "hero_sword_attack" else "hero_attack"
+        hero_animation <- hero_attack_animation()
         enemy_hit_points[[enemy_in_range]] <<- max(0, enemy_hit_points[[enemy_in_range]] - damage)
         play_hero_timed_animation(hero_animation)
         set_combat_status(sprintf(
@@ -565,7 +700,7 @@ server <- function(input, output, session) {
         }
         update_enemy_status()
       } else {
-        play_hero_timed_animation(if (has_sword) "hero_sword_attack" else "hero_attack")
+        play_hero_timed_animation(hero_attack_animation())
       }
 
   }
@@ -860,6 +995,34 @@ server <- function(input, output, session) {
       list(js = "document.getElementById('leave_map').style.display = 'block';")
     )
   }
+
+  choose_character <- function(character) {
+    if (!is.null(selected_character)) return(invisible(NULL))
+
+    selected_character <<- character
+    hero$add_player_controls()
+    hero$set_player_animation_prefix(character)
+    play_hero_idle_animation()
+    map_navigation_background$show()
+    hero$set_depth(98)
+    mushroom_swamps_map_image$show()
+    magma_hills_map_image$show()
+    session$sendCustomMessage(
+      "phaser",
+      list(js = "document.getElementById('character_select').style.display = 'none';")
+    )
+    shinyalert::shinyalert(
+      title = "Use Space to attack and interact",
+      type = "info"
+    )
+  }
+
+  shiny::observeEvent(input$choose_hero, {
+    choose_character("hero")
+  }, ignoreInit = TRUE)
+  shiny::observeEvent(input$choose_orc, {
+    choose_character("hero_orc")
+  }, ignoreInit = TRUE)
 
   shiny::observeEvent(input$leave_map, {
     map_navigation_background$show()

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -283,7 +283,7 @@ server <- function(input, output, session) {
   berry_in_range <- NULL
   hero_last_attack_time <- as.numeric(Sys.time()) - 1
   hero_attack_cooldown <- 0.75
-  hero_sword_damage <- 2
+  hero_weapon_damage <- 2
   health_bar_segment_count <- 10
   health_bar_segment_width <- 18
   health_bar_segment_height <- 14
@@ -374,13 +374,6 @@ server <- function(input, output, session) {
     enemy_status_text$set(paste("enemies:", paste(enemy_summaries, collapse = " | ")))
   }
 
-  hero_idle_animation <- function() {
-    if (identical(selected_character, "hero_orc")) {
-      return("hero_orc_idle")
-    }
-    "hero_sword_idle"
-  }
-
   hero_attack_animation <- function() {
     if (identical(selected_character, "hero_orc")) {
       return("hero_orc_attack")
@@ -388,19 +381,16 @@ server <- function(input, output, session) {
     "hero_sword_attack"
   }
 
-  play_hero_idle_animation <- function() {
-    hero$play_animation(hero_idle_animation())
+  hero_attack_duration <- function() {
+    # At four frames per second, the Orc needs 750 ms to display all three
+    # attack frames before player controls resume the movement animation.
+    if (identical(selected_character, "hero_orc")) 750 else 500
   }
 
-  play_hero_timed_animation <- function(animation_name, duration = 500) {
-    hero$play_animation(animation_name, duration = duration)
-    later::later(
-      function() {
-        if (life_points > 0) {
-          play_hero_idle_animation()
-        }
-      },
-      delay = duration / 1000
+  play_hero_attack_animation <- function() {
+    hero$play_animation(
+      hero_attack_animation(),
+      duration = hero_attack_duration()
     )
   }
 
@@ -703,10 +693,9 @@ server <- function(input, output, session) {
       hero_attack_sound$play()
 
       if (!is.null(enemy_in_range) && isTRUE(enemy_is_alive[[enemy_in_range]])) {
-        damage <- hero_sword_damage
-        hero_animation <- hero_attack_animation()
+        damage <- hero_weapon_damage
         enemy_hit_points[[enemy_in_range]] <<- max(0, enemy_hit_points[[enemy_in_range]] - damage)
-        play_hero_timed_animation(hero_animation)
+        play_hero_attack_animation()
         set_combat_status(sprintf(
           "You hit %s for %d. Enemy life: %d/%d",
           format_enemy_label(enemy_in_range), damage,
@@ -723,7 +712,7 @@ server <- function(input, output, session) {
         }
         update_enemy_status()
       } else {
-        play_hero_timed_animation(hero_attack_animation())
+        play_hero_attack_animation()
       }
 
   }
@@ -735,7 +724,7 @@ server <- function(input, output, session) {
   )
 
   inventory_text <- game$add_text(
-    text = "weapon: sword",
+    text = "weapon: waiting for character",
     id = "inventory_weapon",
     x = 1200,
     y = 85
@@ -1014,7 +1003,9 @@ server <- function(input, output, session) {
     hero$add_player_controls()
     animation_prefix <- if (identical(character, "hero_orc")) character else "hero_sword"
     marker_character <- if (identical(character, "hero_orc")) "orc" else "human"
+    weapon <- if (identical(character, "hero_orc")) "axe" else "sword"
     hero$set_player_animation_prefix(animation_prefix)
+    inventory_text$set(sprintf("weapon: %s", weapon))
     map_navigation_background$show()
     hero$set_depth(98)
     mushroom_swamps_map_image$show()

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -18,7 +18,7 @@ GameBridge.mapLoadQueue = GameBridge.mapLoadQueue || [];
 GameBridge.mapLoading = GameBridge.mapLoading || false;
 GameBridge.mapExits = GameBridge.mapExits || {};
 GameBridge.mapExitVisible = GameBridge.mapExitVisible || false;
-GameBridge.realmNavigationVisible = GameBridge.realmNavigationVisible || false;
+GameBridge.navigationOverlayVisible = GameBridge.navigationOverlayVisible || false;
 GameBridge.lastHeroOverlapState = GameBridge.lastHeroOverlapState || "";
 GameBridge.nextHeroOverlapSendAt = GameBridge.nextHeroOverlapSendAt || 0;
 GameBridge.sounds = GameBridge.sounds || {};
@@ -321,10 +321,13 @@ function setPlayerAnimationPrefix(name, prefix) {
   if (sprite) playIfChanged(sprite, animationPrefix + "_idle");
 }
 
-function setRealmNavigationVisible(visible) {
-  GameBridge.realmNavigationVisible = Boolean(visible);
+function setNavigationOverlayVisible(visible) {
+  GameBridge.navigationOverlayVisible = Boolean(visible);
   const element = document.getElementById("leave_map");
   if (visible && element) element.style.display = "none";
+
+  const marker = document.getElementById("realm_character_marker");
+  if (marker) marker.style.display = visible ? "block" : "none";
 }
 
 function applyWorldBounds(bounds) {
@@ -476,7 +479,7 @@ function setMapExit(mapKey, playerName, x, y, radius, elementId) {
 }
 
 function updateMapExitVisibility() {
-  if (GameBridge.realmNavigationVisible) {
+  if (GameBridge.navigationOverlayVisible) {
     const navigationExit = document.getElementById("leave_map");
     if (navigationExit) navigationExit.style.display = "none";
     GameBridge.mapExitVisible = false;

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -18,6 +18,7 @@ GameBridge.mapLoadQueue = GameBridge.mapLoadQueue || [];
 GameBridge.mapLoading = GameBridge.mapLoading || false;
 GameBridge.mapExits = GameBridge.mapExits || {};
 GameBridge.mapExitVisible = GameBridge.mapExitVisible || false;
+GameBridge.realmNavigationVisible = GameBridge.realmNavigationVisible || false;
 GameBridge.lastHeroOverlapState = GameBridge.lastHeroOverlapState || "";
 GameBridge.nextHeroOverlapSendAt = GameBridge.nextHeroOverlapSendAt || 0;
 GameBridge.sounds = GameBridge.sounds || {};
@@ -312,7 +313,18 @@ function addPlayerControls(name, directions, speed) {
 
 function setPlayerAnimationPrefix(name, prefix) {
   if (!GameBridge.playerControls[name]) return;
-  GameBridge.playerControls[name].animationPrefix = prefix || name;
+  const animationPrefix = prefix || name;
+  GameBridge.playerControls[name].animationPrefix = animationPrefix;
+  delete GameBridge.forcedAnimations[name];
+
+  const sprite = scene && scene.children.getByName(name);
+  if (sprite) playIfChanged(sprite, animationPrefix + "_idle");
+}
+
+function setRealmNavigationVisible(visible) {
+  GameBridge.realmNavigationVisible = Boolean(visible);
+  const element = document.getElementById("leave_map");
+  if (visible && element) element.style.display = "none";
 }
 
 function applyWorldBounds(bounds) {
@@ -464,6 +476,13 @@ function setMapExit(mapKey, playerName, x, y, radius, elementId) {
 }
 
 function updateMapExitVisibility() {
+  if (GameBridge.realmNavigationVisible) {
+    const navigationExit = document.getElementById("leave_map");
+    if (navigationExit) navigationExit.style.display = "none";
+    GameBridge.mapExitVisible = false;
+    return;
+  }
+
   const exit = GameBridge.mapExits[GameBridge.activeMapKey];
   const player = exit && scene && scene.children.getByName(exit.playerName);
   const nearby = Boolean(player && Phaser.Math.Distance.Between(

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -154,6 +154,7 @@ function initPhaserGame(containerId, config) {
           if (!sprite) return;
 
           const { speed, directionMap } = opts;
+          const animationPrefix = opts.animationPrefix || name;
 
           if (directionMap.left || directionMap.right) {
             sprite.body.setVelocityX(0);
@@ -162,30 +163,30 @@ function initPhaserGame(containerId, config) {
             sprite.body.setVelocityY(0);
           }
 
-          let targetAnim = name + '_idle';
+          let targetAnim = animationPrefix + '_idle';
 
           if (cursors.left.isDown && directionMap.left) {
             sprite.body.setVelocityX(-speed);
-            targetAnim = name + '_move_left';
+            targetAnim = animationPrefix + '_move_left';
             rememberMovementDirection(sprite, "left", time);
           } else if (cursors.right.isDown && directionMap.right) {
             sprite.body.setVelocityX(speed);
-            targetAnim = name + '_move_right';
+            targetAnim = animationPrefix + '_move_right';
             rememberMovementDirection(sprite, "right", time);
           } else if (cursors.up.isDown && directionMap.up) {
             sprite.body.setVelocityY(-speed);
-            targetAnim = name + '_move_up';
+            targetAnim = animationPrefix + '_move_up';
             rememberMovementDirection(sprite, "up", time);
           } else if (cursors.down.isDown && directionMap.down) {
             sprite.body.setVelocityY(speed);
-            targetAnim = name + '_move_down';
+            targetAnim = animationPrefix + '_move_down';
             rememberMovementDirection(sprite, "down", time);
           }
 
           const forced = GameBridge.forcedAnimations[name];
           if (forced) {
             if (forced.until === null || time <= forced.until) {
-              const movementKey = targetAnim !== name + '_idle' ? targetAnim : null;
+              const movementKey = targetAnim !== animationPrefix + '_idle' ? targetAnim : null;
               const forcedAnimKey = forcedAnimationForMovement(
                 sprite, forced.key, movementKey, time
               );
@@ -299,6 +300,7 @@ function hideText(id) {
 function addPlayerControls(name, directions, speed) {
   GameBridge.playerControls[name] = {
     speed,
+    animationPrefix: name,
     directionMap: {
       left: directions.includes("left"),
       right: directions.includes("right"),
@@ -307,6 +309,11 @@ function addPlayerControls(name, directions, speed) {
     }
   };
 };
+
+function setPlayerAnimationPrefix(name, prefix) {
+  if (!GameBridge.playerControls[name]) return;
+  GameBridge.playerControls[name].animationPrefix = prefix || name;
+}
 
 function applyWorldBounds(bounds) {
   if (!bounds || !scene || !scene.physics || !scene.cameras) return;

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -381,8 +381,13 @@ test_that("dungeonheroes Space action retains interactions and combat", {
     warn = FALSE
   )
 
-  expect_true(any(grepl("if (sword_in_range && !has_sword)", example, fixed = TRUE)))
-  expect_true(any(grepl('inventory_text$set("weapon: sword")', example, fixed = TRUE)))
+  expect_false(any(grepl("sword_in_range", example, fixed = TRUE)))
+  expect_true(any(grepl(
+    'weapon <- if (identical(character, "hero_orc")) "axe" else "sword"',
+    example,
+    fixed = TRUE
+  )))
+  expect_true(any(grepl('inventory_text$set(sprintf("weapon: %s", weapon))', example, fixed = TRUE)))
   expect_true(any(grepl("if (wizard_in_range)", example, fixed = TRUE)))
   expect_true(any(grepl("server_action = handle_space", example, fixed = TRUE)))
   expect_true(any(grepl("server_action", example, fixed = TRUE)))
@@ -488,7 +493,7 @@ test_that("recent movement selects four-way directional attack animations", {
   expect_true(any(grepl('rememberMovementDirection(sprite, "down", time)', game_js, fixed = TRUE)))
   expect_true(any(grepl('animationKey + "_" + direction', game_js, fixed = TRUE)))
   expect_true(any(grepl('forcedKey + "_" + movementSuffix', game_js, fixed = TRUE)))
-  expect_true(any(grepl("targetAnim !== name + '_idle'", game_js, fixed = TRUE)))
+  expect_true(any(grepl("targetAnim !== animationPrefix + '_idle'", game_js, fixed = TRUE)))
   expect_true(any(grepl('rememberMovementDirection(sprite, movementDirection, now)', sprite_js, fixed = TRUE)))
   expect_true(any(grepl('suffix = paste0("sword_attack_", direction)', example, fixed = TRUE)))
   expect_true(any(grepl('suffix = paste0("attack_", direction)', example, fixed = TRUE)))

--- a/tests/testthat/test-sprites.R
+++ b/tests/testthat/test-sprites.R
@@ -54,3 +54,26 @@ test_that("Sprite add_animation sends explicit frame_count when provided", {
   expect_length(msgs, 2)
   expect_match(msgs[[2]]$message$js, "addSpriteAnimation\\(\"hero\",\"run\",\"run.png\",32,32,6,24\\);")
 })
+
+test_that("Sprite can select a player animation prefix", {
+  session <- make_mock_session()
+  sprite <- Sprite$new(
+    name = "hero",
+    url = "hero.png",
+    x = 0,
+    y = 0,
+    frame_width = 16,
+    frame_height = 16,
+    frame_rate = 8,
+    session = session
+  )
+
+  sprite$set_player_animation_prefix("hero_orc")
+
+  msgs <- session$get_messages()
+  expect_length(msgs, 2)
+  expect_match(
+    msgs[[2]]$message$js,
+    'setPlayerAnimationPrefix\\("hero", "hero_orc"\\);'
+  )
+})


### PR DESCRIPTION
### Motivation
- Provide a start screen so the player chooses between the existing `hero` and the new `orc` assets before entering realm navigation.
- Enable a single player object to drive different animation sets (hero vs orc) without duplicating player logic.
- Prevent gameplay (movement controls and instructions) from starting until the player explicitly picks a character.

### Description
- Add a full-screen character picker UI and styles in `inst/examples/dungeonheroes.R` with two selectable cards (`choose_hero`, `choose_orc`) and logic to hide the picker once a character is chosen.
- Load the orc sprites and animations (`hero_orc_idle`, `hero_orc_move_*`, `hero_orc_attack`) and update idle/attack selection to respect a `selected_character` choice in `inst/examples/dungeonheroes.R`.
- Delay enabling player controls until selection and call `hero$add_player_controls()` from the selection handler, while keeping the existing single `hero` sprite instance and using a selectable animation prefix.
- Add a new API method `Sprite$set_player_animation_prefix()` in `R/sprites.R` that sends `setPlayerAnimationPrefix(...)` to the client, and update `inst/www/phaser-game.js` to support an `animationPrefix` per-player in the movement loop plus a `setPlayerAnimationPrefix` helper.
- Add a unit test `tests/testthat/test-sprites.R` that verifies the generated browser message for setting the player animation prefix.

### Testing
- Ran `node --check inst/www/phaser-game.js` and it completed successfully.
- Ran `git diff --check` (syntax/style checks used during the rollout) and it reported no issues.
- Added `tests/testthat/test-sprites.R` to cover the `setPlayerAnimationPrefix` message, however R tests were not executed because `Rscript` is unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f7cbef7e8832f9c00077be2d635a9)