### PR TITLE
Add start, save, and load menus to Dungeon Heroes

### DIFF
--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -217,8 +217,11 @@ ui <- shiny::tagList(
     #saved_games .empty_save { color: #bcb59e; font-family: sans-serif; }
     #save_game_dialog { z-index: 9700; display: none; background: rgba(0, 0, 0, .72); }
     #save_game_actions { display: flex; gap: 12px; }
-    #save_game {
+    #game_session_actions {
       position: fixed; right: 22px; top: 18px; z-index: 9000; display: none;
+      gap: 10px;
+    }
+    #game_session_actions .game_menu_button {
       width: auto; margin: 0; padding: 11px 20px;
     }
 
@@ -269,7 +272,11 @@ ui <- shiny::tagList(
     "leave_map", "Leave map",
     onclick = "this.style.display = 'none';"
   ),
-  htmltools::tags$button(id = "save_game", class = "game_menu_button", type = "button", "Save game"),
+  htmltools::tags$div(
+    id = "game_session_actions",
+    htmltools::tags$button(id = "save_game", class = "game_menu_button", type = "button", "Save game"),
+    htmltools::tags$button(id = "exit_game", class = "game_menu_button", type = "button", "Exit")
+  ),
   htmltools::tags$div(
     id = "save_game_dialog",
     htmltools::tags$div(
@@ -310,6 +317,7 @@ ui <- shiny::tagList(
       document.addEventListener('DOMContentLoaded', function() {
         document.getElementById('show_load_game').onclick = function() { var h = document.getElementById('saved_games'); h.style.display = 'block'; renderSaves(); };
         document.getElementById('save_game').onclick = function() { var d = document.getElementById('save_game_dialog'); d.style.display = 'flex'; document.getElementById('save_game_name').focus(); };
+        document.getElementById('exit_game').onclick = function() { window.location.reload(); };
         document.getElementById('cancel_save_game').onclick = function() { document.getElementById('save_game_dialog').style.display = 'none'; };
         document.getElementById('confirm_save_game').onclick = function() {
           var name = document.getElementById('save_game_name').value.trim();
@@ -1123,7 +1131,7 @@ server <- function(input, output, session) {
         "setNavigationOverlayVisible(true);",
         "document.getElementById('character_select').style.display = 'none';",
         "document.getElementById('game_start').style.display = 'none';",
-        "document.getElementById('save_game').style.display = 'block';"
+        "document.getElementById('game_session_actions').style.display = 'flex';"
       ))
     )
   }
@@ -1199,7 +1207,7 @@ server <- function(input, output, session) {
         paste(
           "document.getElementById('realm_character_marker').className = %s + ' ' + %s;",
           "document.getElementById('game_start').style.display = 'none';",
-          "document.getElementById('save_game').style.display = 'block';"
+          "document.getElementById('game_session_actions').style.display = 'flex';"
         ),
         jsonlite::toJSON(marker_character, auto_unbox = TRUE),
         jsonlite::toJSON(current_realm, auto_unbox = TRUE)

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -322,7 +322,12 @@ ui <- shiny::tagList(
         document.getElementById('confirm_save_game').onclick = function() {
           var name = document.getElementById('save_game_name').value.trim();
           if (!name) { document.getElementById('save_game_name').focus(); return; }
-          var hero = window.scene && scene.children.getByName('hero');
+          // `scene` is a top-level lexical binding in phaser-game.js, not a
+          // property on `window`. Reading window.scene therefore always used
+          // the fallback entrance coordinates instead of the player's current
+          // position.
+          var activeScene = typeof scene !== 'undefined' ? scene : null;
+          var hero = activeScene && activeScene.children.getByName('hero');
           Shiny.setInputValue('save_game_requested', {name: name, x: hero ? hero.x : 100, y: hero ? hero.y : 100, navigation: !!GameBridge.navigationOverlayVisible, nonce: Date.now()}, {priority: 'event'});
         };
       });

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -42,7 +42,7 @@ ui <- shiny::tagList(
       position: fixed;
       inset: 0;
       z-index: 9500;
-      display: flex;
+      display: none;
       flex-direction: column;
       align-items: center;
       justify-content: center;
@@ -177,11 +177,66 @@ ui <- shiny::tagList(
       cursor: pointer;
     }
 
+    #game_start, #save_game_dialog {
+      position: fixed;
+      inset: 0;
+      z-index: 9600;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(circle at 50% 35%, #3d5146, #080d0b 62%);
+      color: #f6e7bd;
+      font-family: Georgia, serif;
+    }
+
+    .game_menu_panel {
+      width: min(520px, calc(100vw - 48px));
+      padding: 38px;
+      border: 3px solid #8f7140;
+      border-radius: 12px;
+      background: rgba(15, 22, 18, .96);
+      box-shadow: 0 14px 38px #000;
+      text-align: center;
+    }
+
+    .game_menu_panel h1, .game_menu_panel h2 { color: #f5d98b; }
+    .game_menu_button, #save_game_name {
+      box-sizing: border-box;
+      width: 100%;
+      margin-top: 14px;
+      padding: 13px 18px;
+      border: 2px solid #8f7140;
+      border-radius: 6px;
+      background: #202d26;
+      color: #f6e7bd;
+      font: 700 18px sans-serif;
+    }
+    button.game_menu_button { cursor: pointer; }
+    button.game_menu_button:hover { border-color: #f5d98b; background: #304238; }
+    #saved_games { max-height: 260px; overflow-y: auto; }
+    #saved_games .empty_save { color: #bcb59e; font-family: sans-serif; }
+    #save_game_dialog { z-index: 9700; display: none; background: rgba(0, 0, 0, .72); }
+    #save_game_actions { display: flex; gap: 12px; }
+    #save_game {
+      position: fixed; right: 22px; top: 18px; z-index: 9000; display: none;
+      width: auto; margin: 0; padding: 11px 20px;
+    }
+
   ")),
   htmltools::tags$div(
     id = "dungeonheroes_loader",
     htmltools::tags$div(class = "skeleton_loader_sprite"),
     htmltools::tags$div("Loading dungeon heroes...")
+  ),
+  htmltools::tags$div(
+    id = "game_start",
+    htmltools::tags$div(
+      class = "game_menu_panel",
+      htmltools::tags$h1("DUNGEON HEROES"),
+      htmltools::tags$button(id = "new_game", class = "game_menu_button action-button", type = "button", "New game"),
+      htmltools::tags$button(id = "show_load_game", class = "game_menu_button", type = "button", "Load game"),
+      htmltools::tags$div(id = "saved_games", style = "display:none;")
+    )
   ),
   htmltools::tags$div(
     id = "character_select",
@@ -214,8 +269,56 @@ ui <- shiny::tagList(
     "leave_map", "Leave map",
     onclick = "this.style.display = 'none';"
   ),
+  htmltools::tags$button(id = "save_game", class = "game_menu_button", type = "button", "Save game"),
+  htmltools::tags$div(
+    id = "save_game_dialog",
+    htmltools::tags$div(
+      class = "game_menu_panel",
+      htmltools::tags$h2("Save game"),
+      htmltools::tags$label(`for` = "save_game_name", "Name this save"),
+      htmltools::tags$input(id = "save_game_name", type = "text", maxlength = "60", placeholder = "My adventure"),
+      htmltools::tags$div(
+        id = "save_game_actions",
+        htmltools::tags$button(id = "confirm_save_game", class = "game_menu_button", type = "button", "Save"),
+        htmltools::tags$button(id = "cancel_save_game", class = "game_menu_button", type = "button", "Cancel")
+      )
+    )
+  ),
   game$use_phaser(),
   htmltools::tags$script(htmltools::HTML("
+    (function() {
+      var storageKey = 'dungeonheroes.savedGames.v1';
+      function saves() { try { return JSON.parse(localStorage.getItem(storageKey)) || []; } catch (e) { return []; } }
+      function renderSaves() {
+        var host = document.getElementById('saved_games');
+        var items = saves();
+        host.innerHTML = '';
+        if (!items.length) { host.innerHTML = '<p class=\"empty_save\">No saved games yet.</p>'; return; }
+        items.sort(function(a, b) { return b.savedAt.localeCompare(a.savedAt); }).forEach(function(save) {
+          var button = document.createElement('button');
+          button.type = 'button'; button.className = 'game_menu_button';
+          button.textContent = save.name + ' — ' + new Date(save.savedAt).toLocaleString();
+          button.onclick = function() { Shiny.setInputValue('load_game', save, {priority: 'event'}); };
+          host.appendChild(button);
+        });
+      }
+      window.storeDungeonHeroesSave = function(save) {
+        var items = saves().filter(function(item) { return item.name !== save.name; });
+        items.push(save); localStorage.setItem(storageKey, JSON.stringify(items));
+        document.getElementById('save_game_dialog').style.display = 'none'; renderSaves();
+      };
+      document.addEventListener('DOMContentLoaded', function() {
+        document.getElementById('show_load_game').onclick = function() { var h = document.getElementById('saved_games'); h.style.display = 'block'; renderSaves(); };
+        document.getElementById('save_game').onclick = function() { var d = document.getElementById('save_game_dialog'); d.style.display = 'flex'; document.getElementById('save_game_name').focus(); };
+        document.getElementById('cancel_save_game').onclick = function() { document.getElementById('save_game_dialog').style.display = 'none'; };
+        document.getElementById('confirm_save_game').onclick = function() {
+          var name = document.getElementById('save_game_name').value.trim();
+          if (!name) { document.getElementById('save_game_name').focus(); return; }
+          var hero = window.scene && scene.children.getByName('hero');
+          Shiny.setInputValue('save_game_requested', {name: name, x: hero ? hero.x : 100, y: hero ? hero.y : 100, navigation: !!GameBridge.navigationOverlayVisible, nonce: Date.now()}, {priority: 'event'});
+        };
+      });
+    })();
     window.addEventListener('load', function() {
       setTimeout(function() {
         var loader = document.getElementById('dungeonheroes_loader');
@@ -1018,16 +1121,109 @@ server <- function(input, output, session) {
           marker_character, current_realm
         ),
         "setNavigationOverlayVisible(true);",
-        "document.getElementById('character_select').style.display = 'none';"
+        "document.getElementById('character_select').style.display = 'none';",
+        "document.getElementById('game_start').style.display = 'none';",
+        "document.getElementById('save_game').style.display = 'block';"
       ))
     )
   }
+
+  shiny::observeEvent(input$new_game, {
+    session$sendCustomMessage(
+      "phaser",
+      list(js = paste(
+        "document.getElementById('game_start').style.display = 'none';",
+        "document.getElementById('character_select').style.display = 'flex';"
+      ))
+    )
+  }, ignoreInit = TRUE)
 
   shiny::observeEvent(input$choose_hero, {
     choose_character("hero")
   }, ignoreInit = TRUE)
   shiny::observeEvent(input$choose_orc, {
     choose_character("hero_orc")
+  }, ignoreInit = TRUE)
+
+  shiny::observeEvent(input$save_game_requested, {
+    request <- input$save_game_requested
+    save <- list(
+      name = as.character(request$name),
+      savedAt = format(Sys.time(), "%Y-%m-%dT%H:%M:%OS3Z", tz = "UTC"),
+      character = selected_character,
+      realm = current_realm,
+      navigation = isTRUE(request$navigation),
+      x = as.numeric(request$x),
+      y = as.numeric(request$y),
+      lifePoints = life_points,
+      enemyHitPoints = as.list(enemy_hit_points),
+      enemyIsAlive = as.list(enemy_is_alive),
+      berriesAvailable = as.list(berry_is_available)
+    )
+    session$sendCustomMessage(
+      "phaser",
+      list(js = sprintf(
+        "storeDungeonHeroesSave(%s);",
+        jsonlite::toJSON(save, auto_unbox = TRUE, null = "null")
+      ))
+    )
+  }, ignoreInit = TRUE)
+
+  shiny::observeEvent(input$load_game, {
+    save <- input$load_game
+    if (is.null(save$character) || !save$character %in% c("hero", "hero_orc")) return()
+
+    choose_character(save$character)
+    current_realm <<- if (identical(save$realm, "magma_hills")) "magma_hills" else "mushroom_swamps"
+    life_points <<- max(0, min(max_life_points, as.numeric(save$lifePoints %||% max_life_points)))
+    update_life_points()
+
+    saved_enemy_hp <- unlist(save$enemyHitPoints)
+    saved_enemy_alive <- unlist(save$enemyIsAlive)
+    common_enemies <- intersect(enemy_names, names(saved_enemy_hp))
+    enemy_hit_points[common_enemies] <<- as.numeric(saved_enemy_hp[common_enemies])
+    common_alive <- intersect(enemy_names, names(saved_enemy_alive))
+    enemy_is_alive[common_alive] <<- as.logical(saved_enemy_alive[common_alive])
+    saved_berries <- unlist(save$berriesAvailable)
+    common_berries <- intersect(names(berries), names(saved_berries))
+    berry_is_available[common_berries] <<- as.logical(saved_berries[common_berries])
+    update_enemy_status()
+
+    marker_character <- if (identical(save$character, "hero_orc")) "orc" else "human"
+    x <- as.numeric(save$x %||% 100)
+    y <- as.numeric(save$y %||% 100)
+    on_navigation <- isTRUE(save$navigation)
+    session$sendCustomMessage(
+      "phaser",
+      list(js = sprintf(
+        paste(
+          "document.getElementById('realm_character_marker').className = %s + ' ' + %s;",
+          "document.getElementById('game_start').style.display = 'none';",
+          "document.getElementById('save_game').style.display = 'block';"
+        ),
+        jsonlite::toJSON(marker_character, auto_unbox = TRUE),
+        jsonlite::toJSON(current_realm, auto_unbox = TRUE)
+      ))
+    )
+    if (on_navigation) {
+      map_navigation_background$show()
+      hero$set_depth(98)
+      lapply(navigation_images, function(image) image$show())
+      session$sendCustomMessage("phaser", list(js = "setNavigationOverlayVisible(true);"))
+    } else {
+      hide_map_navigation()
+      persistent_objects <- c("dead_tree_1_bottom", "dead_tree_1_top", "wizard", "mushroom_spirit")
+      available_objects <- c(enemy_names[enemy_is_alive], names(berries)[berry_is_available], persistent_objects)
+      unavailable_objects <- c(enemy_names[!enemy_is_alive], names(berries)[!berry_is_available])
+      visible <- if (identical(current_realm, "mushroom_swamps")) available_objects else character()
+      hidden <- if (identical(current_realm, "magma_hills")) {
+        c(mushroom_swamps_objects, "talk_bubble_text")
+      } else {
+        unavailable_objects
+      }
+      game$activate_map(current_realm, player_name = "hero", x = x, y = y,
+                        visible_objects = visible, hidden_objects = hidden)
+    }
   }, ignoreInit = TRUE)
 
   shiny::observeEvent(input$leave_map, {


### PR DESCRIPTION
### Motivation
- Provide a clear initial entry point so players can start a new run or resume a previous save, and make saving available from any in-game context.

### Description
- Added a styled opening screen (`#game_start`) with `New game` and `Load game` buttons and an in-page saved-slot list implemented in browser `localStorage` via inline JS in `inst/examples/dungeonheroes.R`.
- Kept hero selection exclusive to the `New game` flow by hiding the character chooser until `New game` is selected and added a `new_game` input observer to open it programmatically.
- Added a persistent in-game `Save game` button and a named-save modal (`#save_game_dialog`) that sends `save_game_requested` to the server; the server responds by sending a JSON save back to the browser via `storeDungeonHeroesSave()` to persist slots.
- Implemented restore logic on `load_game` that reinstates `character`, `realm` (or realm navigation), `x/y` coordinates, `life_points`, `enemy` hit points / alive state, and `berries` availability and uses `game$activate_map` or the navigation overlay to return the player to the saved context.

### Testing
- Ran `git diff --check` to ensure no whitespace or obvious diff errors and it passed.
- Extracted the inline browser script and validated its JavaScript syntax with `node --check /tmp/dungeonheroes-inline.js` and it passed.
- Attempted to parse/run R checks with `Rscript`, but `R`/`Rscript` is not available in the environment so R-based tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7038de011c832fb291f8fc49fbef8e)