### PR TITLE
Add server-side Phaser game save and load support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,8 +53,6 @@
 ## Updates in examples
 * Added new arcade example game (bear).
 * Added new RPG game example (dungeonheroes).
-* Updated dungeonheroes to store saves on the server, capture the hero's live
-  Phaser coordinates, and expose Save and Exit from a top-left game menu.
 * Updated the hedgehog examples so acknowledging a game-over dialog reloads the Shiny session and starts a fresh game instead of stopping the app.
 
 ## README

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,15 @@
 * Queued sprite physics actions until sprites finish loading so setup calls such as `set_gravity()` are not lost during asynchronous asset initialization.
 
 ## New interface features
+* Added `PhaserGame$save_game()` for persisting application state and live
+  Phaser object snapshots to server-side JSON files. Saves default to a
+  game-specific directory below `tempdir()` and can also accept an explicitly
+  captured snapshot for an immediate disk write.
+* Added `PhaserGame$list_saved_games()` for retrieving the available
+  server-side saves in newest-first order.
+* Added `PhaserGame$load_game()` for reading saved application state and
+  optionally restoring captured Phaser object positions, visibility, and active
+  state in the running scene.
 * Added `Sprite$set_player_animation_prefix()` for switching the idle and directional movement animation set used by player controls at runtime.
 * Added `gravity_x` and `gravity_y` parameters to `PhaserGame$new()` for configuring Arcade Physics world gravity when a game is created.
 * Added sound support with `PhaserGame$add_sound()` and a new `Sound` API for loading, playing, pausing, resuming, stopping, and configuring audio.
@@ -44,6 +53,8 @@
 ## Updates in examples
 * Added new arcade example game (bear).
 * Added new RPG game example (dungeonheroes).
+* Updated dungeonheroes to store saves on the server, capture the hero's live
+  Phaser coordinates, and expose Save and Exit from a top-left game menu.
 * Updated the hedgehog examples so acknowledging a game-over dialog reloads the Shiny session and starts a fresh game instead of stopping the app.
 
 ## README

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -49,18 +49,28 @@ PhaserGame <- R6::R6Class(
     #' @param state Named list. Additional JSON-serializable application state.
     #' @param objects Character vector. Named Phaser scene objects to capture. By
     #'   default all named scene objects are captured.
+    #' @param snapshot Named list. Optional Phaser object snapshot already
+    #'   captured in the browser. Supplying it writes the save synchronously.
     #' @param directory Character. Server-side directory. Defaults to a
     #'   game-specific folder below [tempdir()].
     #' @return Invisible request identifier. The disk write completes
     #'   asynchronously after Phaser returns its snapshot.
-    save_game = function(name, state = list(), objects = NULL, directory = NULL) {
+    save_game = function(name, state = list(), objects = NULL, snapshot = NULL,
+                         directory = NULL) {
       private$set_save_directory(directory)
       private$register_save_handler()
+      name <- trimws(as.character(name)[1])
+      if (!nzchar(name)) stop("name must not be empty.", call. = FALSE)
+      if (!is.null(snapshot)) {
+        record <- private$write_save(name, state, snapshot)
+        if (!is.null(private$session)) {
+          private$session$sendCustomMessage("phaser-save-complete", record)
+        }
+        return(invisible(record))
+      }
       if (is.null(private$save_observer)) {
         stop("A Shiny session must be set before save_game() is called.", call. = FALSE)
       }
-      name <- trimws(as.character(name)[1])
-      if (!nzchar(name)) stop("name must not be empty.", call. = FALSE)
       request_id <- paste0(as.integer(Sys.time()), "-", sample.int(1e9, 1))
       js <- sprintf(
         "capturePhaserGameState(%s, %s, %s, %s);",
@@ -490,6 +500,18 @@ PhaserGame <- R6::R6Class(
     save_file = NULL,
     save_input_id = NULL,
     save_observer = NULL,
+    write_save = function(name, state, objects) {
+      saves <- read_phaser_saves(private$save_file)
+      record <- list(
+        name = as.character(name),
+        savedAt = format(Sys.time(), "%Y-%m-%dT%H:%M:%OS3Z", tz = "UTC"),
+        state = state %||% list(),
+        phaser = list(objects = objects %||% list())
+      )
+      keep <- !vapply(saves, function(x) identical(x$name, record$name), logical(1))
+      write_phaser_saves(c(saves[keep], list(record)), private$save_file)
+      record
+    },
     set_save_directory = function(directory = NULL) {
       if (!is.null(directory)) private$save_directory <- normalizePath(directory, mustWork = FALSE)
       if (is.null(private$save_directory)) {
@@ -506,15 +528,7 @@ PhaserGame <- R6::R6Class(
       private$save_observer <- shiny::observeEvent(
         private$session$input[[private$save_input_id]], {
           request <- private$session$input[[private$save_input_id]]
-          saves <- read_phaser_saves(private$save_file)
-          record <- list(
-            name = as.character(request$name),
-            savedAt = format(Sys.time(), "%Y-%m-%dT%H:%M:%OS3Z", tz = "UTC"),
-            state = request$state %||% list(),
-            phaser = list(objects = request$objects %||% list())
-          )
-          keep <- !vapply(saves, function(x) identical(x$name, record$name), logical(1))
-          write_phaser_saves(c(saves[keep], list(record)), private$save_file)
+          record <- private$write_save(request$name, request$state, request$objects)
           private$session$sendCustomMessage("phaser-save-complete", record)
         }, ignoreInit = TRUE
       )

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -39,6 +39,67 @@ PhaserGame <- R6::R6Class(
     #' @param session Shiny session object (default: shiny::getDefaultReactiveDomain()).
     set_shiny_session = function(session = shiny::getDefaultReactiveDomain()) {
       private$session <- session
+      private$register_save_handler()
+    },
+
+    #' @description Save game data and Phaser object state to a JSON file on the
+    #'   server. Positions are read directly from Phaser immediately before the
+    #'   save request, avoiding stale Shiny coordinates.
+    #' @param name Character. Human-readable name of the save.
+    #' @param state Named list. Additional JSON-serializable application state.
+    #' @param objects Character vector. Named Phaser scene objects to capture. By
+    #'   default all named scene objects are captured.
+    #' @param directory Character. Server-side directory. Defaults to a
+    #'   game-specific folder below [tempdir()].
+    #' @return Invisible request identifier. The disk write completes
+    #'   asynchronously after Phaser returns its snapshot.
+    save_game = function(name, state = list(), objects = NULL, directory = NULL) {
+      private$set_save_directory(directory)
+      private$register_save_handler()
+      if (is.null(private$save_observer)) {
+        stop("A Shiny session must be set before save_game() is called.", call. = FALSE)
+      }
+      name <- trimws(as.character(name)[1])
+      if (!nzchar(name)) stop("name must not be empty.", call. = FALSE)
+      request_id <- paste0(as.integer(Sys.time()), "-", sample.int(1e9, 1))
+      js <- sprintf(
+        "capturePhaserGameState(%s, %s, %s, %s);",
+        jsonlite::toJSON(private$save_input_id, auto_unbox = TRUE),
+        jsonlite::toJSON(request_id, auto_unbox = TRUE),
+        jsonlite::toJSON(name, auto_unbox = TRUE),
+        jsonlite::toJSON(list(state = state, objects = objects), auto_unbox = TRUE, null = "null")
+      )
+      send_js(private, js)
+      invisible(request_id)
+    },
+
+    #' @description List saves stored on the server for this game.
+    #' @param directory Character. Server-side save directory.
+    #' @return A list of saved game records, newest first.
+    list_saved_games = function(directory = NULL) {
+      private$set_save_directory(directory)
+      saves <- read_phaser_saves(private$save_file)
+      if (!length(saves)) return(saves)
+      saves[order(vapply(saves, function(x) x$savedAt %||% "", character(1)), decreasing = TRUE)]
+    },
+
+    #' @description Load a saved game from server disk.
+    #' @param name Character. Save name.
+    #' @param restore Logical. Restore captured Phaser object properties.
+    #' @param directory Character. Server-side save directory.
+    #' @return The additional application state stored with the save, invisibly.
+    load_game = function(name, restore = TRUE, directory = NULL) {
+      saves <- self$list_saved_games(directory)
+      matches <- which(vapply(saves, function(x) identical(x$name, as.character(name)[1]), logical(1)))
+      if (!length(matches)) stop(sprintf("Saved game '%s' was not found.", name), call. = FALSE)
+      save <- saves[[matches[1]]]
+      if (isTRUE(restore)) {
+        send_js(private, sprintf("restorePhaserGameState(%s);",
+          jsonlite::toJSON(save$phaser, auto_unbox = TRUE, null = "null")))
+      }
+      state <- save$state %||% list()
+      state$phaser <- save$phaser %||% list(objects = list())
+      invisible(state)
     },
 
     #' @description Load dependencies and initialize the Phaser game in the UI.
@@ -424,7 +485,40 @@ PhaserGame <- R6::R6Class(
   private = list(
     config = list(),
     input = NULL,
-    session = NULL
+    session = NULL,
+    save_directory = NULL,
+    save_file = NULL,
+    save_input_id = NULL,
+    save_observer = NULL,
+    set_save_directory = function(directory = NULL) {
+      if (!is.null(directory)) private$save_directory <- normalizePath(directory, mustWork = FALSE)
+      if (is.null(private$save_directory)) {
+        private$save_directory <- file.path(tempdir(), "shinyphaser", self$id)
+      }
+      dir.create(private$save_directory, recursive = TRUE, showWarnings = FALSE)
+      private$save_file <- file.path(private$save_directory, "save-games.json")
+    },
+    register_save_handler = function() {
+      if (!is.null(private$save_observer) || is.null(private$session) ||
+          is.null(private$session$input)) return(invisible(NULL))
+      private$save_input_id <- paste0(self$id, "_save_game_state")
+      private$set_save_directory()
+      private$save_observer <- shiny::observeEvent(
+        private$session$input[[private$save_input_id]], {
+          request <- private$session$input[[private$save_input_id]]
+          saves <- read_phaser_saves(private$save_file)
+          record <- list(
+            name = as.character(request$name),
+            savedAt = format(Sys.time(), "%Y-%m-%dT%H:%M:%OS3Z", tz = "UTC"),
+            state = request$state %||% list(),
+            phaser = list(objects = request$objects %||% list())
+          )
+          keep <- !vapply(saves, function(x) identical(x$name, record$name), logical(1))
+          write_phaser_saves(c(saves[keep], list(record)), private$save_file)
+          private$session$sendCustomMessage("phaser-save-complete", record)
+        }, ignoreInit = TRUE
+      )
+    }
   )
 )
 

--- a/R/save_game.R
+++ b/R/save_game.R
@@ -1,0 +1,19 @@
+read_phaser_saves <- function(path) {
+  if (!file.exists(path)) return(list())
+  result <- tryCatch(
+    jsonlite::fromJSON(path, simplifyVector = FALSE),
+    error = function(e) list()
+  )
+  if (is.list(result)) result else list()
+}
+
+write_phaser_saves <- function(saves, path) {
+  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+  temporary <- tempfile("save-games-", tmpdir = dirname(path), fileext = ".json")
+  jsonlite::write_json(saves, temporary, auto_unbox = TRUE, null = "null", pretty = TRUE)
+  if (!file.rename(temporary, path)) {
+    unlink(temporary)
+    stop("Could not replace the saved-game file.", call. = FALSE)
+  }
+  invisible(path)
+}

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -294,41 +294,35 @@ ui <- shiny::tagList(
   game$use_phaser(),
   htmltools::tags$script(htmltools::HTML("
     (function() {
-      var storageKey = 'dungeonheroes.savedGames.v1';
-      function saves() { try { return JSON.parse(localStorage.getItem(storageKey)) || []; } catch (e) { return []; } }
-      function renderSaves() {
+      function renderSaves(items) {
         var host = document.getElementById('saved_games');
-        var items = saves();
         host.innerHTML = '';
         if (!items.length) { host.innerHTML = '<p class=\"empty_save\">No saved games yet.</p>'; return; }
-        items.sort(function(a, b) { return b.savedAt.localeCompare(a.savedAt); }).forEach(function(save) {
+        items.forEach(function(save) {
           var button = document.createElement('button');
           button.type = 'button'; button.className = 'game_menu_button';
           button.textContent = save.name + ' — ' + new Date(save.savedAt).toLocaleString();
-          button.onclick = function() { Shiny.setInputValue('load_game', save, {priority: 'event'}); };
+          button.onclick = function() { Shiny.setInputValue('load_game', {name: save.name, nonce: Date.now()}, {priority: 'event'}); };
           host.appendChild(button);
         });
       }
-      window.storeDungeonHeroesSave = function(save) {
-        var items = saves().filter(function(item) { return item.name !== save.name; });
-        items.push(save); localStorage.setItem(storageKey, JSON.stringify(items));
-        document.getElementById('save_game_dialog').style.display = 'none'; renderSaves();
-      };
+      window.renderDungeonHeroesSaves = renderSaves;
+      window.addEventListener('shinyphaser:saved', function() {
+        document.getElementById('save_game_dialog').style.display = 'none';
+        Shiny.setInputValue('list_saved_games', Date.now(), {priority: 'event'});
+      });
       document.addEventListener('DOMContentLoaded', function() {
-        document.getElementById('show_load_game').onclick = function() { var h = document.getElementById('saved_games'); h.style.display = 'block'; renderSaves(); };
+        document.getElementById('show_load_game').onclick = function() {
+          document.getElementById('saved_games').style.display = 'block';
+          Shiny.setInputValue('list_saved_games', Date.now(), {priority: 'event'});
+        };
         document.getElementById('save_game').onclick = function() { var d = document.getElementById('save_game_dialog'); d.style.display = 'flex'; document.getElementById('save_game_name').focus(); };
         document.getElementById('exit_game').onclick = function() { window.location.reload(); };
         document.getElementById('cancel_save_game').onclick = function() { document.getElementById('save_game_dialog').style.display = 'none'; };
         document.getElementById('confirm_save_game').onclick = function() {
           var name = document.getElementById('save_game_name').value.trim();
           if (!name) { document.getElementById('save_game_name').focus(); return; }
-          // `scene` is a top-level lexical binding in phaser-game.js, not a
-          // property on `window`. Reading window.scene therefore always used
-          // the fallback entrance coordinates instead of the player's current
-          // position.
-          var activeScene = typeof scene !== 'undefined' ? scene : null;
-          var hero = activeScene && activeScene.children.getByName('hero');
-          Shiny.setInputValue('save_game_requested', {name: name, x: hero ? hero.x : 100, y: hero ? hero.y : 100, navigation: !!GameBridge.navigationOverlayVisible, nonce: Date.now()}, {priority: 'event'});
+          Shiny.setInputValue('save_game_requested', {name: name, navigation: !!GameBridge.navigationOverlayVisible, nonce: Date.now()}, {priority: 'event'});
         };
       });
     })();
@@ -1158,32 +1152,37 @@ server <- function(input, output, session) {
     choose_character("hero_orc")
   }, ignoreInit = TRUE)
 
+  send_saved_games <- function() {
+    summaries <- lapply(game$list_saved_games(), function(save) {
+      list(name = save$name, savedAt = save$savedAt)
+    })
+    session$sendCustomMessage("phaser", list(js = sprintf(
+      "renderDungeonHeroesSaves(%s);",
+      jsonlite::toJSON(summaries, auto_unbox = TRUE, null = "null")
+    )))
+  }
+
+  shiny::observeEvent(input$list_saved_games, send_saved_games(), ignoreInit = TRUE)
+
   shiny::observeEvent(input$save_game_requested, {
     request <- input$save_game_requested
-    save <- list(
+    game$save_game(
       name = as.character(request$name),
-      savedAt = format(Sys.time(), "%Y-%m-%dT%H:%M:%OS3Z", tz = "UTC"),
-      character = selected_character,
-      realm = current_realm,
-      navigation = isTRUE(request$navigation),
-      x = as.numeric(request$x),
-      y = as.numeric(request$y),
-      lifePoints = life_points,
-      enemyHitPoints = as.list(enemy_hit_points),
-      enemyIsAlive = as.list(enemy_is_alive),
-      berriesAvailable = as.list(berry_is_available)
-    )
-    session$sendCustomMessage(
-      "phaser",
-      list(js = sprintf(
-        "storeDungeonHeroesSave(%s);",
-        jsonlite::toJSON(save, auto_unbox = TRUE, null = "null")
-      ))
+      objects = "hero",
+      state = list(
+        character = selected_character,
+        realm = current_realm,
+        navigation = isTRUE(request$navigation),
+        lifePoints = life_points,
+        enemyHitPoints = as.list(enemy_hit_points),
+        enemyIsAlive = as.list(enemy_is_alive),
+        berriesAvailable = as.list(berry_is_available)
+      )
     )
   }, ignoreInit = TRUE)
 
   shiny::observeEvent(input$load_game, {
-    save <- input$load_game
+    save <- game$load_game(input$load_game$name, restore = FALSE)
     if (is.null(save$character) || !save$character %in% c("hero", "hero_orc")) return()
 
     choose_character(save$character)
@@ -1203,8 +1202,9 @@ server <- function(input, output, session) {
     update_enemy_status()
 
     marker_character <- if (identical(save$character, "hero_orc")) "orc" else "human"
-    x <- as.numeric(save$x %||% 100)
-    y <- as.numeric(save$y %||% 100)
+    saved_hero <- save$phaser$objects$hero %||% list()
+    x <- as.numeric(saved_hero$x %||% 100)
+    y <- as.numeric(saved_hero$y %||% 100)
     on_navigation <- isTRUE(save$navigation)
     session$sendCustomMessage(
       "phaser",

--- a/inst/examples/dungeonheroes.R
+++ b/inst/examples/dungeonheroes.R
@@ -218,12 +218,17 @@ ui <- shiny::tagList(
     #save_game_dialog { z-index: 9700; display: none; background: rgba(0, 0, 0, .72); }
     #save_game_actions { display: flex; gap: 12px; }
     #game_session_actions {
-      position: fixed; right: 22px; top: 18px; z-index: 9000; display: none;
-      gap: 10px;
+      position: fixed; left: 18px; top: 18px; z-index: 9000; display: none;
     }
     #game_session_actions .game_menu_button {
       width: auto; margin: 0; padding: 11px 20px;
     }
+    #game_session_menu {
+      display: none; width: 190px; margin-top: 8px; padding: 8px;
+      border: 2px solid #8f7140; border-radius: 6px;
+      background: rgba(15, 22, 18, .96); box-shadow: 0 8px 24px #000;
+    }
+    #game_session_menu .game_menu_button { width: 100%; margin-top: 6px; }
 
   ")),
   htmltools::tags$div(
@@ -274,8 +279,13 @@ ui <- shiny::tagList(
   ),
   htmltools::tags$div(
     id = "game_session_actions",
-    htmltools::tags$button(id = "save_game", class = "game_menu_button", type = "button", "Save game"),
-    htmltools::tags$button(id = "exit_game", class = "game_menu_button", type = "button", "Exit")
+    htmltools::tags$button(id = "toggle_game_menu", class = "game_menu_button", type = "button",
+                          `aria-expanded` = "false", "Menu"),
+    htmltools::tags$div(
+      id = "game_session_menu",
+      htmltools::tags$button(id = "save_game", class = "game_menu_button", type = "button", "Save game"),
+      htmltools::tags$button(id = "exit_game", class = "game_menu_button", type = "button", "Exit")
+    )
   ),
   htmltools::tags$div(
     id = "save_game_dialog",
@@ -316,13 +326,22 @@ ui <- shiny::tagList(
           document.getElementById('saved_games').style.display = 'block';
           Shiny.setInputValue('list_saved_games', Date.now(), {priority: 'event'});
         };
-        document.getElementById('save_game').onclick = function() { var d = document.getElementById('save_game_dialog'); d.style.display = 'flex'; document.getElementById('save_game_name').focus(); };
+        document.getElementById('toggle_game_menu').onclick = function() {
+          var menu = document.getElementById('game_session_menu');
+          var open = menu.style.display === 'block';
+          menu.style.display = open ? 'none' : 'block';
+          this.setAttribute('aria-expanded', open ? 'false' : 'true');
+        };
+        document.getElementById('save_game').onclick = function() { document.getElementById('game_session_menu').style.display = 'none'; var d = document.getElementById('save_game_dialog'); d.style.display = 'flex'; document.getElementById('save_game_name').focus(); };
         document.getElementById('exit_game').onclick = function() { window.location.reload(); };
         document.getElementById('cancel_save_game').onclick = function() { document.getElementById('save_game_dialog').style.display = 'none'; };
         document.getElementById('confirm_save_game').onclick = function() {
           var name = document.getElementById('save_game_name').value.trim();
           if (!name) { document.getElementById('save_game_name').focus(); return; }
-          Shiny.setInputValue('save_game_requested', {name: name, navigation: !!GameBridge.navigationOverlayVisible, nonce: Date.now()}, {priority: 'event'});
+          capturePhaserGameState('save_game_requested', String(Date.now()), name, {
+            objects: ['hero'],
+            state: {navigation: !!GameBridge.navigationOverlayVisible}
+          });
         };
       });
     })();
@@ -1168,11 +1187,11 @@ server <- function(input, output, session) {
     request <- input$save_game_requested
     game$save_game(
       name = as.character(request$name),
-      objects = "hero",
+      snapshot = request$objects,
       state = list(
         character = selected_character,
         realm = current_realm,
-        navigation = isTRUE(request$navigation),
+        navigation = isTRUE(request$state$navigation),
         lifePoints = life_points,
         enemyHitPoints = as.list(enemy_hit_points),
         enemyIsAlive = as.list(enemy_is_alive),

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -708,6 +708,55 @@ function sendHeroOverlapState(time) {
   );
 }
 
+// Phaser owns the live transforms, so snapshot them at the instant a save is
+// requested instead of relying on coordinates previously delivered to Shiny.
+function capturePhaserGameState(inputId, requestId, name, options = {}) {
+  if (!scene || !shinyInputReady()) return;
+  const requested = Array.isArray(options.objects) ? new Set(options.objects) : null;
+  const objects = {};
+  scene.children.list.forEach((object) => {
+    if (!object.name || (requested && !requested.has(object.name))) return;
+    objects[object.name] = {
+      x: object.x,
+      y: object.y,
+      visible: object.visible,
+      active: object.active
+    };
+  });
+  Shiny.setInputValue(inputId, {
+    requestId,
+    name,
+    state: options.state || {},
+    objects,
+    evt_nonce: Date.now() + Math.random()
+  }, { priority: "event" });
+}
+
+function restorePhaserGameState(snapshot, attempts = 40) {
+  const pending = [];
+  Object.entries(snapshot?.objects || {}).forEach(([name, saved]) => {
+    const object = scene && scene.children.getByName(name);
+    if (!object) { pending.push(name); return; }
+    if (Number.isFinite(saved.x) && Number.isFinite(saved.y)) {
+      object.setPosition(saved.x, saved.y);
+      // Arcade bodies retain their own previous position; reset both values so
+      // the next physics tick cannot snap the hero back to the old location.
+      if (object.body && typeof object.body.reset === "function") {
+        object.body.reset(saved.x, saved.y);
+      }
+    }
+    if (typeof saved.visible === "boolean") object.setVisible(saved.visible);
+    if (typeof saved.active === "boolean") object.setActive(saved.active);
+  });
+  if (pending.length && attempts > 0) {
+    window.setTimeout(() => restorePhaserGameState(snapshot, attempts - 1), 100);
+  }
+}
+
 Shiny.addCustomMessageHandler("phaser", function (message) {
   eval(message.js);
+});
+
+Shiny.addCustomMessageHandler("phaser-save-complete", function (save) {
+  window.dispatchEvent(new CustomEvent("shinyphaser:saved", { detail: save }));
 });

--- a/man/PhaserGame.Rd
+++ b/man/PhaserGame.Rd
@@ -113,11 +113,18 @@ Set the Shiny session used to send Phaser custom messages.
 \if{html}{\out{<a id="method-PhaserGame-save_game"></a>}}
 \subsection{Method \code{save_game()}}{
 Save application state and live Phaser object transforms to server-side JSON.
-\subsection{Usage}{\preformatted{PhaserGame$save_game(name, state = list(), objects = NULL, directory = NULL)}}
+\subsection{Usage}{\preformatted{PhaserGame$save_game(
+  name,
+  state = list(),
+  objects = NULL,
+  snapshot = NULL,
+  directory = NULL
+)}}
 \subsection{Arguments}{\describe{
 \item{\code{name}}{Human-readable save name.}
 \item{\code{state}}{Named list of application state.}
 \item{\code{objects}}{Named Phaser objects to capture; \code{NULL} captures all named objects.}
+\item{\code{snapshot}}{Optional Phaser object snapshot already captured by the browser.}
 \item{\code{directory}}{Server directory; defaults below \code{tempdir()}.}
 }}
 }

--- a/man/PhaserGame.Rd
+++ b/man/PhaserGame.Rd
@@ -33,6 +33,9 @@ game <- PhaserGame$new(id = "my_game", width = 1024, height = 768)
 \itemize{
 \item \href{#method-PhaserGame-new}{\code{PhaserGame$new()}}
 \item \href{#method-PhaserGame-set_shiny_session}{\code{PhaserGame$set_shiny_session()}}
+\item \href{#method-PhaserGame-save_game}{\code{PhaserGame$save_game()}}
+\item \href{#method-PhaserGame-list_saved_games}{\code{PhaserGame$list_saved_games()}}
+\item \href{#method-PhaserGame-load_game}{\code{PhaserGame$load_game()}}
 \item \href{#method-PhaserGame-use_phaser}{\code{PhaserGame$use_phaser()}}
 \item \href{#method-PhaserGame-add_text}{\code{PhaserGame$add_text()}}
 \item \href{#method-PhaserGame-add_rectangle}{\code{PhaserGame$add_rectangle()}}
@@ -105,6 +108,30 @@ Set the Shiny session used to send Phaser custom messages.
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-PhaserGame-save_game"></a>}}
+\subsection{Method \code{save_game()}}{
+Save application state and live Phaser object transforms to server-side JSON.
+\subsection{Usage}{\preformatted{PhaserGame$save_game(name, state = list(), objects = NULL, directory = NULL)}}
+\subsection{Arguments}{\describe{
+\item{\code{name}}{Human-readable save name.}
+\item{\code{state}}{Named list of application state.}
+\item{\code{objects}}{Named Phaser objects to capture; \code{NULL} captures all named objects.}
+\item{\code{directory}}{Server directory; defaults below \code{tempdir()}.}
+}}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-PhaserGame-list_saved_games"></a>}}
+\subsection{Method \code{list_saved_games()}}{
+List server-side saves, newest first.
+\subsection{Usage}{\preformatted{PhaserGame$list_saved_games(directory = NULL)}}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-PhaserGame-load_game"></a>}}
+\subsection{Method \code{load_game()}}{
+Load application state and optionally restore captured Phaser objects.
+\subsection{Usage}{\preformatted{PhaserGame$load_game(name, restore = TRUE, directory = NULL)}}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-PhaserGame-use_phaser"></a>}}

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -574,3 +574,30 @@ test_that("save file helpers replace named JSON records", {
   expect_true(file.exists(path))
   expect_equal(read_phaser_saves(path), saves)
 })
+
+test_that("dungeonheroes captures its hero before the synchronous disk save", {
+  example <- readLines(system.file("examples", "dungeonheroes.R", package = "shinyphaser"), warn = FALSE)
+
+  expect_true(any(grepl("capturePhaserGameState('save_game_requested'", example, fixed = TRUE)))
+  expect_true(any(grepl("snapshot = request$objects", example, fixed = TRUE)))
+  expect_true(any(grepl('id = "toggle_game_menu"', example, fixed = TRUE)))
+  expect_true(any(grepl('position: fixed; left: 18px; top: 18px', example, fixed = TRUE)))
+})
+
+test_that("save_game writes a supplied Phaser snapshot immediately", {
+  directory <- tempfile("shinyphaser-game-")
+  game <- PhaserGame$new(id = "save-test")
+
+  game$save_game(
+    "checkpoint",
+    state = list(score = 12),
+    snapshot = list(hero = list(x = 321, y = 654)),
+    directory = directory
+  )
+
+  saves <- game$list_saved_games(directory)
+  expect_length(saves, 1)
+  expect_equal(saves[[1]]$phaser$objects$hero$x, 321)
+  loaded <- game$load_game("checkpoint", restore = FALSE, directory = directory)
+  expect_equal(loaded$score, 12)
+})

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -553,3 +553,24 @@ test_that("bear uses Arcade world gravity", {
   expect_true(any(grepl("gravity_y = 1200", bear, fixed = TRUE)))
   expect_false(any(grepl("$set_gravity", bear, fixed = TRUE)))
 })
+
+test_that("saved games use Phaser snapshots and server disk persistence", {
+  game_js <- readLines(system.file("www", "phaser-game.js", package = "shinyphaser"), warn = FALSE)
+  example <- readLines(system.file("examples", "dungeonheroes.R", package = "shinyphaser"), warn = FALSE)
+
+  expect_true(any(grepl("function capturePhaserGameState", game_js, fixed = TRUE)))
+  expect_true(any(grepl("object.body.reset(saved.x, saved.y)", game_js, fixed = TRUE)))
+  expect_false(any(grepl("localStorage", example, fixed = TRUE)))
+  expect_true(any(grepl('game$save_game(', example, fixed = TRUE)))
+  expect_true(any(grepl('game$load_game(input$load_game$name', example, fixed = TRUE)))
+})
+
+test_that("save file helpers replace named JSON records", {
+  directory <- tempfile("shinyphaser-saves-")
+  path <- file.path(directory, "save-games.json")
+  saves <- list(list(name = "first", savedAt = "2026-01-01", state = list(score = 1)))
+
+  write_phaser_saves(saves, path)
+  expect_true(file.exists(path))
+  expect_equal(read_phaser_saves(path), saves)
+})


### PR DESCRIPTION
### Motivation

- Replace fragile browser-only `localStorage` saves with a server-side, disk-backed save system so saves persist outside the client and can be accessed via R code.  
- Provide an R-friendly API so apps can trigger saves and loads programmatically (e.g. `PhaserGame$save_game()`), enabling integration from server-side logic.  
- Capture live Phaser object transforms from the running scene to avoid stale coordinates sent earlier to Shiny and fix the bug where the hero sometimes snaps back to previous positions.  

### Description

- Added new public methods on `PhaserGame`: `save_game()`, `list_saved_games()`, and `load_game()`, and wired a private save handler that listens for Phaser snapshots and writes JSON files under a game-specific folder within `tempdir()`; see `R/PhaserGame.R`.  
- Implemented atomic JSON persistence helpers `read_phaser_saves()` and `write_phaser_saves()` in `R/save_game.R` to safely replace save files on disk.  
- Added client-side Phaser snapshot and restore helpers in `inst/www/phaser-game.js`: `capturePhaserGameState()` reads live `scene.children` coordinates, and `restorePhaserGameState()` sets object positions and calls `body.reset()` for Arcade physics bodies to prevent snapping back.  
- Migrated the Dungeon Heroes example (`inst/examples/dungeonheroes.R`) away from `localStorage` to use the new save API and added UI glue to list server saves; updated docs (`man/PhaserGame.Rd`) and added tests that assert the new behavior.  

### Testing

- Ran `git diff --check` which produced no whitespace or merge issues and succeeded.  
- Ran `node --check inst/www/phaser-game.js` to validate injected JavaScript and it succeeded.  
- Verified by textual checks that the example no longer references `localStorage` and now uses `game$save_game()` / `game$load_game()`.  
- R unit tests were added to `tests/testthat/` to cover snapshot helpers and file helpers, but they were not executed in this environment because `Rscript` / full R tooling was unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70973369ac832fbecbef8939e59164)