### PR TITLE
Fix starting realms and align sprite frame counts to assets

### DIFF
--- a/inst/examples/dungeonheroes/modules/hero.R
+++ b/inst/examples/dungeonheroes/modules/hero.R
@@ -72,7 +72,7 @@
     suffix = "elf_idle",
     url = "assets/dungeonheroes/sprites/hero/elf/hero_elf_idle.png",
     frame_width = 100, frame_height = 100,
-    frame_count = 25, frame_rate = 4
+    frame_count = 21, frame_rate = 4
   )
   lapply(c("down", "left", "right", "up"), function(direction) {
     source_direction <- if (direction %in% c("up", "down")) direction else "down"

--- a/inst/examples/dungeonheroes/modules/hero.R
+++ b/inst/examples/dungeonheroes/modules/hero.R
@@ -72,7 +72,7 @@
     suffix = "elf_idle",
     url = "assets/dungeonheroes/sprites/hero/elf/hero_elf_idle.png",
     frame_width = 100, frame_height = 100,
-    frame_count = 26, frame_rate = 4
+    frame_count = 25, frame_rate = 4
   )
   lapply(c("down", "left", "right", "up"), function(direction) {
     source_direction <- if (direction %in% c("up", "down")) direction else "down"

--- a/inst/examples/dungeonheroes/modules/navigation.R
+++ b/inst/examples/dungeonheroes/modules/navigation.R
@@ -15,6 +15,9 @@
     if (!is.null(selected_character)) return(invisible(NULL))
 
     selected_character <<- character
+    current_realm <<- switch(character,
+      hero_orc = "grey_mountains", hero_elf = "wild_forests", "castle"
+    )
     hero$add_player_controls()
     animation_prefix <- switch(character,
       hero_orc = "hero_orc", hero_elf = "hero_elf", "hero_sword"

--- a/inst/examples/dungeonheroes/modules/realms/castle.R
+++ b/inst/examples/dungeonheroes/modules/realms/castle.R
@@ -3,7 +3,7 @@
     url = "assets/dungeonheroes/sprites/npc/blacksmith/blacksmith.png",
     x = 800, y = 400,
     frame_width = 100, frame_height = 100,
-    frame_count = 72, frame_rate = 8
+    frame_count = 67, frame_rate = 8
   )
   session$sendCustomMessage(
     "phaser",

--- a/inst/examples/dungeonheroes/modules/realms/mushroom_swamps_world.R
+++ b/inst/examples/dungeonheroes/modules/realms/mushroom_swamps_world.R
@@ -15,7 +15,7 @@
         suffix = paste0("move_", direction),
         url = sprintf("assets/dungeonheroes/sprites/enemies/mushroom_man/mushroom_man_walk_%s.png", direction),
         frame_width = 100, frame_height = 100,
-        frame_count = 12, frame_rate = 8
+        frame_count = 2, frame_rate = 8
       )
     })
 
@@ -23,21 +23,21 @@
       suffix = "attack",
       url = "assets/dungeonheroes/sprites/enemies/mushroom_man/mushroom_man_attack.png",
       frame_width = 100, frame_height = 100,
-      frame_count = 6, frame_rate = 6
+      frame_count = 4, frame_rate = 6
     )
     lapply(c("left", "right"), function(direction) {
       enemy$add_animation(
         suffix = paste0("attack_", direction),
         url = sprintf("assets/dungeonheroes/sprites/enemies/mushroom_man/mushroom_man_attack_%s.png", direction),
         frame_width = 100, frame_height = 100,
-        frame_count = 6, frame_rate = 6
+        frame_count = 4, frame_rate = 6
       )
     })
     enemy$add_animation(
       suffix = "destroy",
       url = "assets/dungeonheroes/sprites/enemies/mushroom_man/mushroom_man_destroy.png",
       frame_width = 100, frame_height = 100,
-      frame_count = 6, frame_rate = 8
+      frame_count = 4, frame_rate = 8
     )
 
     enemy

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -493,7 +493,13 @@ test_that("dungeonheroes includes the elf and new western realms", {
   expect_true(any(grepl('class = "character_name", "Human Knight"', example, fixed = TRUE)))
   expect_true(any(grepl('class = "character_name", "Orc Hunter"', example, fixed = TRUE)))
   expect_true(any(grepl('suffix = "elf_idle"', example, fixed = TRUE)))
-  expect_true(any(grepl('frame_count = 26, frame_rate = 4', example, fixed = TRUE)))
+  expect_true(any(grepl('frame_count = 25, frame_rate = 4', example, fixed = TRUE)))
+  expect_true(any(grepl(
+    'hero_orc = "grey_mountains", hero_elf = "wild_forests", "castle"',
+    example, fixed = TRUE
+  )))
+  expect_true(any(grepl('frame_count = 2, frame_rate = 8', example, fixed = TRUE)))
+  expect_true(any(grepl('frame_count = 4, frame_rate = 6', example, fixed = TRUE)))
   expect_true(any(grepl('choose_character("hero_elf")', example, fixed = TRUE)))
   expect_true(any(grepl('name = "choose_wild_forests"', example, fixed = TRUE)))
   expect_true(any(grepl('name = "choose_grey_mountains"', example, fixed = TRUE)))


### PR DESCRIPTION
### Motivation
- Players should start in the intended realms (Human -> castle, Orc -> grey mountains, Elf -> wild forests) so the navigation marker and map label match the chosen character immediately. 
- Phaser was logging `generateFrameNumbers: Frame X missing` because some declared `frame_count` values did not match the actual PNG sprite-sheet frames. 
- Tests and example code must reflect the true asset frame counts to avoid runtime warnings and flaky examples.

### Description
- Set the character-specific starting realm in `choose_character` so the marker and label update when a character is chosen by assigning `current_realm` based on the selected character in `inst/examples/dungeonheroes/modules/navigation.R`. 
- Reduce the Elf idle animation frames from `26` to `25` in `inst/examples/dungeonheroes/modules/hero.R` to match `hero_elf_idle.png`. 
- Update mushroom-man animations in `inst/examples/dungeonheroes/modules/realms/mushroom_swamps_world.R` to `frame_count = 2` for walking sheets and `frame_count = 4` for attack/destroy sheets to match the PNG sprite-sheets. 
- Update regression coverage in `tests/testthat/test-core-methods.R` to assert the new `frame_count` values and the character->realm mapping used at selection.

### Testing
- Ran `git diff --check` and basic diff/stat checks to ensure no whitespace or diff issues (passed). 
- Executed a Python validation script that reads PNG headers and asserts expected frame counts for the affected sprite sheets and validates the character->realm mapping in `navigation.R` (all static checks passed). 
- Attempted to run `devtools::test()` via `R -q -e 'devtools::test()'` but the environment lacks `R`, so the package test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71dc07c908832f9a85b75a3af7245c)