### PR TITLE
Add directional orc attack animations

### DIFF
--- a/inst/examples/dungeonheroes/modules/hero.R
+++ b/inst/examples/dungeonheroes/modules/hero.R
@@ -67,6 +67,14 @@
     frame_width = 100, frame_height = 100,
     frame_count = 3, frame_rate = 4
   )
+  lapply(c("down", "up", "left", "right"), function(direction) {
+    hero$add_animation(
+      suffix = paste0("orc_attack_", direction),
+      url = sprintf("assets/dungeonheroes/sprites/hero/orc/hero_orc_attack_%s.png", direction),
+      frame_width = 100, frame_height = 100,
+      frame_count = 3, frame_rate = 4
+    )
+  })
 
   hero$add_animation(
     suffix = "elf_idle",

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -572,6 +572,8 @@ test_that("recent movement selects four-way directional attack animations", {
   expect_true(any(grepl("targetAnim !== animationPrefix + '_idle'", game_js, fixed = TRUE)))
   expect_true(any(grepl('rememberMovementDirection(sprite, movementDirection, now)', sprite_js, fixed = TRUE)))
   expect_true(any(grepl('suffix = paste0("sword_attack_", direction)', example, fixed = TRUE)))
+  expect_true(any(grepl('suffix = paste0("orc_attack_", direction)', example, fixed = TRUE)))
+  expect_true(any(grepl('hero_orc_attack_%s.png', example, fixed = TRUE)))
   expect_true(any(grepl('suffix = paste0("attack_", direction)', example, fixed = TRUE)))
 })
 


### PR DESCRIPTION
### Motivation
- Register the newly provided directional Orc attack sprite sheets so the existing directional-attack selection logic can play `orc_attack_<direction>` variants.

### Description
- Add four directional orc attack animations in `inst/examples/dungeonheroes/modules/hero.R` by registering `orc_attack_down`, `orc_attack_up`, `orc_attack_left`, and `orc_attack_right` via `hero$add_animation`.
- Extend the directional-attack regression test in `tests/testthat/test-core-methods.R` to assert the example registers `suffix = paste0("orc_attack_", direction)` and references the `hero_orc_attack_%s.png` asset names.

### Testing
- Tried to run the updated `testthat` test with `Rscript -e 'testthat::test_file("tests/testthat/test-core-methods.R", reporter = "summary")'` but the command could not be executed because `Rscript` is not installed in the environment, so automated tests were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7249c4be90832f9b47c0c99c047a60)