### PR TITLE
Simplify map object visibility during activation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # shinyphaser (development version)
 
+* Simplified `PhaserGame$activate_map()` object visibility: callers now list
+  only the objects that the activated map should show, and previously managed
+  map objects are hidden automatically.
 * Split event handling into explicit `browser_action` and `server_action`
   parameters. Browser-side calls must now be declared with `browser_actions()`,
   while arbitrary R logic belongs in a server action.

--- a/R/PhaserGame.R
+++ b/R/PhaserGame.R
@@ -229,17 +229,17 @@ PhaserGame <- R6::R6Class(
     #' @param player_name Character. Optional player sprite to reposition.
     #' @param x Numeric. Optional player x-coordinate.
     #' @param y Numeric. Optional player y-coordinate.
-    #' @param visible_objects Character vector. Scene objects to show and enable.
-    #' @param hidden_objects Character vector. Scene objects to hide and disable.
+    #' @param objects Character vector. Scene objects to show and enable. Objects
+    #'   shown by an earlier map activation are hidden automatically.
     #' @return Invisible; sends a custom message to the client.
     activate_map = function(map_key, player_name = NULL, x = NULL, y = NULL,
-                            visible_objects = character(), hidden_objects = character()) {
+                            objects = character()) {
       js_value <- function(value) jsonlite::toJSON(value, auto_unbox = TRUE, null = "null")
       js_array <- function(value) jsonlite::toJSON(value, auto_unbox = FALSE, null = "null")
       js <- sprintf(
-        "activateMap(%s, %s, %s, %s, %s, %s);",
+        "activateMap(%s, %s, %s, %s, %s);",
         js_value(map_key), js_value(player_name), js_value(x), js_value(y),
-        js_array(visible_objects), js_array(hidden_objects)
+        js_array(objects)
       )
       send_js(private, js)
     },

--- a/inst/examples/dungeonheroes/modules/realms/castle.R
+++ b/inst/examples/dungeonheroes/modules/realms/castle.R
@@ -16,8 +16,7 @@
     hide_map_navigation()
     game$activate_map(
       current_realm, player_name = "hero", x = 700, y = 500,
-      visible_objects = "blacksmith",
-      hidden_objects = c(mushroom_swamps_objects, wild_forests_objects, "talk_bubble_text")
+      objects = "blacksmith"
     )
     enemy_status_text$set("enemies: none in the castle")
     set_combat_status("The castle blacksmith is at his forge.")

--- a/inst/examples/dungeonheroes/modules/realms/grey_mountains.R
+++ b/inst/examples/dungeonheroes/modules/realms/grey_mountains.R
@@ -3,8 +3,7 @@
     move_realm_marker(current_realm)
     hide_map_navigation()
     game$activate_map(
-      current_realm, player_name = "hero", x = 100, y = 100,
-      hidden_objects = c(mushroom_swamps_objects, wild_forests_objects, "talk_bubble_text", "blacksmith")
+      current_realm, player_name = "hero", x = 100, y = 100
     )
     enemy_status_text$set("enemies: none in grey mountains")
     set_combat_status("Explore the grey mountains.")

--- a/inst/examples/dungeonheroes/modules/realms/magma_hills.R
+++ b/inst/examples/dungeonheroes/modules/realms/magma_hills.R
@@ -5,8 +5,7 @@
     game$activate_map(
       # Magma hills has its own hill-top arrival point, separate from the
       # mushroom swamps entrance at (100, 100).
-      "magma_hills", player_name = "hero", x = 1550, y = 650,
-      hidden_objects = c(mushroom_swamps_objects, wild_forests_objects, "talk_bubble_text", "blacksmith")
+      "magma_hills", player_name = "hero", x = 1550, y = 650
     )
     enemy_status_text$set("enemies: none in magma hills")
     set_combat_status("Explore the hills. Lava is impassable.")

--- a/inst/examples/dungeonheroes/modules/realms/mushroom_swamps.R
+++ b/inst/examples/dungeonheroes/modules/realms/mushroom_swamps.R
@@ -4,8 +4,7 @@
     hide_map_navigation()
     game$activate_map(
       "mushroom_swamps", player_name = "hero", x = 100, y = 100,
-      visible_objects = mushroom_swamps_objects,
-      hidden_objects = c(wild_forests_objects, "blacksmith")
+      objects = mushroom_swamps_objects
     )
     update_enemy_status()
     set_combat_status("Back in the mushroom swamps.")

--- a/inst/examples/dungeonheroes/modules/realms/wild_forests.R
+++ b/inst/examples/dungeonheroes/modules/realms/wild_forests.R
@@ -4,8 +4,7 @@
     hide_map_navigation()
     game$activate_map(
       current_realm, player_name = "hero", x = 100, y = 100,
-      visible_objects = wild_forests_objects,
-      hidden_objects = c(mushroom_swamps_objects, "talk_bubble_text", "blacksmith")
+      objects = wild_forests_objects
     )
     enemy_status_text$set("enemies: none in wild forests")
     set_combat_status("Explore the wild forests.")

--- a/inst/examples/dungeonheroes/modules/saving.R
+++ b/inst/examples/dungeonheroes/modules/saving.R
@@ -86,15 +86,7 @@
       } else if (identical(current_realm, "castle")) {
         "blacksmith"
       } else character()
-      hidden <- if (identical(current_realm, "mushroom_swamps")) {
-        c(unavailable_objects, wild_forests_objects, "blacksmith")
-      } else if (identical(current_realm, "wild_forests")) {
-        c(mushroom_swamps_objects, unavailable_objects, "talk_bubble_text", "blacksmith")
-      } else {
-        c(mushroom_swamps_objects, wild_forests_objects, "talk_bubble_text", "blacksmith")
-      }
-      if (identical(current_realm, "castle")) hidden <- setdiff(hidden, "blacksmith")
       game$activate_map(current_realm, player_name = "hero", x = x, y = y,
-                        visible_objects = visible, hidden_objects = hidden)
+                        objects = visible)
     }
   }, ignoreInit = TRUE)

--- a/inst/www/phaser-game.js
+++ b/inst/www/phaser-game.js
@@ -19,6 +19,7 @@ GameBridge.mapLoading = GameBridge.mapLoading || false;
 GameBridge.mapExits = GameBridge.mapExits || {};
 GameBridge.mapExitVisible = GameBridge.mapExitVisible || false;
 GameBridge.realmObjectVisibility = GameBridge.realmObjectVisibility || {};
+GameBridge.mapObjects = GameBridge.mapObjects || new Set();
 GameBridge.navigationOverlayVisible = GameBridge.navigationOverlayVisible || false;
 GameBridge.lastHeroOverlapState = GameBridge.lastHeroOverlapState || "";
 GameBridge.nextHeroOverlapSendAt = GameBridge.nextHeroOverlapSendAt || 0;
@@ -453,22 +454,16 @@ function loadNextMap() {
 }
 
 function activateMap(mapKey, playerName = null, x = null, y = null,
-                     visibleObjects = [], hiddenObjects = []) {
+                     objects = []) {
   // R JSON serializers can simplify a one-item vector to a scalar. Normalize
-  // both arguments so realm activation remains safe for zero, one, or many
-  // objects, including messages produced by older shinyphaser versions.
-  visibleObjects = Array.isArray(visibleObjects)
-    ? visibleObjects
-    : (visibleObjects == null ? [] : [visibleObjects]);
-  hiddenObjects = Array.isArray(hiddenObjects)
-    ? hiddenObjects
-    : (hiddenObjects == null ? [] : [hiddenObjects]);
+  // the argument so map activation remains safe for zero, one, or many objects.
+  objects = Array.isArray(objects) ? objects : (objects == null ? [] : [objects]);
 
   const mapEntry = GameBridge.maps[mapKey];
   if (!mapEntry) {
     GameBridge.pendingActiveMap = {
       mapKey,
-      args: [mapKey, playerName, x, y, visibleObjects, hiddenObjects]
+      args: [mapKey, playerName, x, y, objects]
     };
     return;
   }
@@ -484,9 +479,9 @@ function activateMap(mapKey, playerName = null, x = null, y = null,
   scene.physics.world.setBounds(0, 0, mapEntry.map.widthInPixels, mapEntry.map.heightInPixels);
   scene.cameras.main.setBounds(0, 0, mapEntry.map.widthInPixels, mapEntry.map.heightInPixels);
 
-  [...visibleObjects.map((name) => [name, true]),
-   ...hiddenObjects.map((name) => [name, false])].forEach(([name, visible]) => {
-    setRealmObjectVisibility(name, visible);
+  objects.forEach((name) => GameBridge.mapObjects.add(name));
+  GameBridge.mapObjects.forEach((name) => {
+    setRealmObjectVisibility(name, objects.includes(name));
   });
 
   const player = playerName && scene.children.getByName(playerName);

--- a/tests/testthat/test-core-methods.R
+++ b/tests/testthat/test-core-methods.R
@@ -209,24 +209,24 @@ test_that("PhaserGame can create Sound objects", {
   expect_true(any(grepl("addSound\\(\\\"jump\\\", \\\"jump.wav\\\", 0.400000, true\\);", msgs)))
 })
 
-test_that("activate_map serializes realm object arguments as arrays", {
+test_that("activate_map serializes map objects as an array", {
   session <- make_mock_session()
   game <- PhaserGame$new()
   game$set_shiny_session(session)
 
   game$activate_map(
     "castle", player_name = "hero", x = 700, y = 500,
-    visible_objects = "blacksmith", hidden_objects = "dead_tree"
+    objects = "blacksmith"
   )
-  game$activate_map("mushroom_swamps", visible_objects = character())
+  game$activate_map("mushroom_swamps", objects = character())
 
   msgs <- vapply(session$get_messages(), function(m) m$message$js, character(1))
   expect_true(any(grepl(
-    'activateMap("castle", "hero", 700, 500, ["blacksmith"], ["dead_tree"]);',
+    'activateMap("castle", "hero", 700, 500, ["blacksmith"]);',
     msgs, fixed = TRUE
   )))
   expect_true(any(grepl(
-    'activateMap("mushroom_swamps", null, null, null, [], []);',
+    'activateMap("mushroom_swamps", null, null, null, []);',
     msgs, fixed = TRUE
   )))
 })
@@ -591,7 +591,7 @@ test_that("wild forests has passable foreground vegetation and berries", {
     "add_berry_handlers(names(forest_berries))", example, fixed = TRUE
   )))
   expect_true(any(grepl(
-    "visible_objects = wild_forests_objects", example, fixed = TRUE
+    "objects = wild_forests_objects", example, fixed = TRUE
   )))
 })
 


### PR DESCRIPTION
### Motivation
- Replace the dual `visible_objects`/`hidden_objects` model with a single positive `objects` argument so map activation callers explicitly list only objects to show while previously-managed map objects are hidden automatically.

### Description
- Change `PhaserGame$activate_map()` to accept a single `objects` character vector and send it to the browser instead of `visible_objects`/`hidden_objects`.
- Update browser runtime to track `GameBridge.mapObjects` and to compute visibility by showing objects listed in the new `objects` argument and hiding previously tracked map objects that are omitted.
- Update Dungeon Heroes example code and save/restore logic to use the new `objects` parameter instead of `visible_objects`/`hidden_objects`.
- Update unit test serialization expectations and add a NEWS entry describing the API simplification.

### Testing
- ✅ `node --check inst/www/phaser-game.js` succeeded and validated the modified JS syntax.
- ✅ `git diff --check` succeeded with no whitespace or merge-marker issues.
- ⚠️ `R -q -e 'devtools::test()'` could not be run because R is not installed in the environment.
- ⚠️ `make_pr`/MCP invocation could not complete in this environment due to missing/blocked MCP startup dependencies and network restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79e69c493c832f85501d24041eba45)