### PR TITLE
Add release checklist, API audit, and minimal save/load example

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,7 +37,13 @@
 ## Updates in examples
 * Added new arcade example game (bear).
 * Added new RPG game example (dungeonheroes).
+* Added a minimal save/load example that keeps authoritative game state in R,
+  persists it with `saveRDS()`, and reapplies it through the public scene API.
 * Updated the hedgehog examples so acknowledging a game-over dialog reloads the Shiny session and starts a fresh game instead of stopping the app.
+
+## Release preparation
+* Added a release checklist and public-API audit, including methods that should
+  be generalized or moved out of the package before the next release.
 
 ## README
 * Added CRAN downloads badge to README.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,58 @@
+# Release readiness
+
+This checklist compares the development version (`0.1.0.9014`) with the first
+CRAN release (`0.1.0`). It deliberately separates reusable Phaser concepts from
+helpers that were introduced to support a particular example game.
+
+## Before submitting
+
+- [ ] Choose the release version and add a dated heading to `NEWS.md`.
+- [ ] Run `devtools::document()` with the package's declared roxygen2 version and
+  review the generated `NAMESPACE` and `man/` changes.
+- [ ] Run `devtools::check()` locally, `R CMD check --as-cran`, and checks on the
+  oldest and newest supported R versions.
+- [ ] Run the Shiny browser tests in an environment with Chrome.
+- [ ] Check the three small examples in `inst/examples/` after removing Dungeon
+  Heroes and ensure that no documentation links to its assets.
+- [ ] Review bundled asset licenses and package size, then update
+  `cran-comments.md` with check results and any incoming-check notes.
+- [ ] Build the pkgdown site only after the public API and generated reference
+  files are final.
+
+## API audit
+
+The following development additions map directly to general Phaser concepts and
+should remain public: world gravity and bounds, sound controls, camera following,
+scroll factors, display depth, visibility, sprite motion/velocity/gravity/bounce,
+colliders, overlaps, keyboard controls, and browser/server actions.
+
+The browser action system is also general, but it is intentionally a small DSL,
+not arbitrary R evaluation. Its supported methods and error behaviour should be
+treated as public API and kept covered by compiler and JavaScript runtime tests.
+
+The following methods need a decision before release:
+
+| Method | Assessment | Recommended release action |
+|---|---|---|
+| `PhaserGame$add_map()` | The name is generic, but the implementation creates exactly one tilemap layer, calls it terrain internally, enables collision from a `collides` tile property, and changes world/camera bounds. | Rename to `add_tilemap_layer()` or extend it with explicit layer, collision-property, and bounds options. Keep `add_map()` as a deprecated alias if compatibility is required. There is no `activate_map()` method in the current R API. |
+| `PhaserGame$enable_terrain_collision()` | “Terrain” and “player” terminology in the JavaScript helper are RPG-oriented; the operation is a collider between a scene object and a tilemap layer. | Replace with an object/layer API such as `add_tilemap_collider(object, layer)`. |
+| `Sprite$set_in_motion_random_or_toward()` | Encodes a particular NPC behaviour (random wandering, sight distance, then chasing). | Move to an example helper or replace with composable position, distance, and movement primitives. |
+| `Sprite$start_approach_on_sight()` | Encodes enemy perception, alerting, and approach timing. | Move to the Dungeon Heroes example before that example is removed; do not promise it as core API. |
+| `StaticGroup$disable(evt)` | The operation is useful for collectibles, but requiring an overlap payload is narrower than a normal group/member API. | Keep only if the event-payload contract is documented; eventually return member handles from `create()` and disable/destroy those handles. |
+| `PhaserGame$are_overlap()` | General concept, but the current method contains an undefined fallback variable and continuously registers a browser check. | Fix its object-only input ID and define lifecycle/cleanup semantics before release. |
+
+## Save/load scope
+
+Saving and loading is possible today when R owns the authoritative state. The
+`inst/examples/save-load.R` example saves an R list with `saveRDS()`, restores it
+with `readRDS()`, and reapplies the value through the existing `Text$set()` API.
+An application can use a database instead of an RDS file with the same pattern.
+
+The current API cannot create a complete snapshot of a running browser-owned
+scene. In particular, `BrowserState` is write-only from R, and scene object
+positions, velocities, animation state, disabled group members, camera state,
+and sound playback cannot be queried as one serializable value. A future generic
+persistence API should therefore provide an explicit browser-to-Shiny state
+request (or scene snapshot) and stable setters for every state that can be
+restored. It should not embed filesystem or RPG-specific save-slot policy in the
+Phaser interface.

--- a/inst/examples/save-load.R
+++ b/inst/examples/save-load.R
@@ -1,0 +1,50 @@
+# A minimal save/load example using R as the authoritative state store.
+# Run after installing shinyphaser with:
+# shiny::runApp(system.file("examples/save-load.R", package = "shinyphaser"))
+
+library(shiny)
+library(shinyphaser)
+
+game <- PhaserGame$new(width = 640, height = 360)
+
+ui <- fluidPage(
+  game$use_phaser(),
+  actionButton("save", "Save score"),
+  actionButton("load", "Load score"),
+  textOutput("status")
+)
+
+server <- function(input, output, session) {
+  game$set_shiny_session(session)
+  score <- reactiveVal(0L)
+  save_file <- file.path(tempdir(), paste0("shinyphaser-", session$token, ".rds"))
+
+  score_text <- game$add_text("Score: 0", "score", 30, 30)
+
+  # Space changes state in R, so the same state can be persisted by R.
+  game$add_control(
+    key = "Space",
+    input = input,
+    server_action = function(event) {
+      score(score() + 1L)
+      score_text$set(paste("Score:", score()))
+    }
+  )
+
+  observeEvent(input$save, {
+    saveRDS(list(score = score()), save_file)
+    output$status <- renderText("Game saved")
+  })
+
+  observeEvent(input$load, {
+    req(file.exists(save_file))
+    saved <- readRDS(save_file)
+    score(saved$score)
+    score_text$set(paste("Score:", score()))
+    output$status <- renderText("Game loaded")
+  })
+
+  session$onSessionEnded(function() unlink(save_file))
+}
+
+shinyApp(ui, server)

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -1,0 +1,10 @@
+test_that("save/load example is installed and uses public state restoration", {
+  example <- readLines(
+    testthat::test_path("..", "..", "inst", "examples", "save-load.R"),
+    warn = FALSE
+  )
+
+  expect_true(any(grepl("saveRDS(list(score = score())", example, fixed = TRUE)))
+  expect_true(any(grepl("saved <- readRDS(save_file)", example, fixed = TRUE)))
+  expect_true(any(grepl("score_text$set(paste", example, fixed = TRUE)))
+})


### PR DESCRIPTION
### Motivation
- Prepare the repository for the next CRAN release by auditing recently-added development APIs for generality and by providing a small, well-scoped example to replace the RPG-heavy demo.
- Confirm which new methods are generic Phaser concepts and which are example-specific helpers that should be moved or renamed before release.

### Description
- Add `RELEASE.md` containing a release-readiness checklist and an API audit that flags methods to generalize or move (notably `add_map()` / tilemap handling, `enable_terrain_collision()`, `Sprite$set_in_motion_random_or_toward()`, `Sprite$start_approach_on_sight()`, `StaticGroup$disable(evt)`, and `PhaserGame$are_overlap()`).
- Add `inst/examples/save-load.R`, a minimal runnable example that keeps authoritative state in R, persists it with `saveRDS()`, restores it with `readRDS()`, and reapplies UI state via the existing `Text$set()` API.
- Add `tests/testthat/test-examples.R` to assert the save/load example uses the intended public persistence and restoration pattern, and update `NEWS.md` to document the new example and release-preparation work.

### Testing
- Ran repository checks: `git diff --check` succeeded and working tree was validated locally.
- Static parse checks of new R files were not executed because `Rscript` is not available in the environment, so `devtools::test()` and example parsing were not run here.
- Attempted to call the local `make_pr` helper but it could not run due to missing Python dependencies and network restrictions preventing package installation, so PR metadata submission was not completed from this environment.
- The new regression test file was added to the test suite but was not executed in this environment due to the missing R runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7aaf509584832fbe470a1b97080898)